### PR TITLE
 [#844] Add pause and resume feature

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,5 +37,6 @@ Bhawesh Panwar <panwarbhawesh1112@gmail.com>
 Frank Heikens <frank@elevarq.com>
 Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
 Ameen Sakr <ameensakr623@gmail.com>
+Abdallah Hany <abdallah.hany1974@gmail.com>
 Rohan Mishra <kmrrohan29@gmail.com>
 youssef-joe <joe92228@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ Bhawesh Panwar <panwarbhawesh1112@gmail.com>
 Frank Heikens <frank@elevarq.com>
 Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
 Ameen Sakr <ameensakr623@gmail.com>
+Abdallah Hany <abdallah.hany1974@gmail.com>
 Rohan Mishra <kmrrohan29@gmail.com>
 youssef-joe <joe92228@gmail.com>
 Mohammad El-Shennawy <mohamedwork216@gmail.com>

--- a/contrib/grafana/pgagroal-pool-details.json
+++ b/contrib/grafana/pgagroal-pool-details.json
@@ -1488,6 +1488,466 @@
             ],
             "title": "Server Errors",
             "type": "timeseries"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 44
+            },
+            "id": 103,
+            "panels": [],
+            "title": "Pause / Resume",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "description": "Number of servers currently paused (pgagroal_server_pause_state == 1).",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "noValue": "0",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "yellow",
+                                "value": 1
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 0,
+                "y": 45
+            },
+            "id": 40,
+            "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "value"
+            },
+            "pluginVersion": "10.0.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "expr": "sum(pgagroal_server_pause_state{instance=~\"$instance\"})",
+                    "instant": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Servers Paused",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "description": "Seconds since the current pause began (0 when nothing is paused).",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "noValue": "0",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "yellow",
+                                "value": 1
+                            },
+                            {
+                                "color": "red",
+                                "value": 300
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 6,
+                "y": 45
+            },
+            "id": 41,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "value_and_name"
+            },
+            "pluginVersion": "10.0.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "expr": "time() - (pgagroal_server_last_paused_timestamp{instance=~\"$instance\"} != 0)",
+                    "instant": true,
+                    "refId": "A",
+                    "legendFormat": "{{name}}"
+                }
+            ],
+            "title": "Pause Duration",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "description": "Total connections still in use (draining) across all paused servers.",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "noValue": "0",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "yellow",
+                                "value": 1
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 12,
+                "y": 45
+            },
+            "id": 42,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "value"
+            },
+            "pluginVersion": "10.0.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "expr": "sum(pgagroal_pause_pending_active_connections{instance=~\"$instance\"})",
+                    "instant": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Draining Connections",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "description": "Servers that are paused and fully drained (paused with 0 active connections still in use).",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "noValue": "0",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "blue",
+                                "value": 1
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 18,
+                "y": 45
+            },
+            "id": 43,
+            "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "value"
+            },
+            "pluginVersion": "10.0.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "expr": "count(pgagroal_server_pause_state{instance=~\"$instance\"} == 1 and pgagroal_pause_pending_active_connections{instance=~\"$instance\"} == 0)",
+                    "instant": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Fully Paused (Drained)",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "description": "Per-server pause state over time (0 = running, 1 = paused).",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "custom": {
+                        "fillOpacity": 70,
+                        "lineWidth": 0,
+                        "insertNulls": false
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "0": {
+                                    "color": "green",
+                                    "index": 0,
+                                    "text": "running"
+                                },
+                                "1": {
+                                    "color": "orange",
+                                    "index": 1,
+                                    "text": "paused"
+                                }
+                            },
+                            "type": "value"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "orange",
+                                "value": 1
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 50
+            },
+            "id": 44,
+            "options": {
+                "legend": {
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": false
+                },
+                "mergeValues": true,
+                "rowHeight": 0.9,
+                "showValue": "auto",
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "10.0.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "expr": "pgagroal_server_pause_state{instance=~\"$instance\"}",
+                    "legendFormat": "{{name}}",
+                    "refId": "A"
+                }
+            ],
+            "title": "Server Pause State",
+            "type": "state-timeline"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+            },
+            "description": "Connections still STATE_IN_USE on paused servers. When this reaches 0 for a paused server, it is fully drained.",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 20,
+                        "gradientMode": "opacity",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "stepAfter",
+                        "lineWidth": 2,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 50
+            },
+            "id": 45,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "max",
+                        "last"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "expr": "pgagroal_pause_pending_active_connections{instance=~\"$instance\"}",
+                    "legendFormat": "{{name}}",
+                    "refId": "A"
+                }
+            ],
+            "title": "Draining Connections (per server)",
+            "type": "timeseries"
         }
     ],
     "refresh": "30s",

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -297,7 +297,7 @@ The `SIGHUP` signal will trigger a full reload of the configuration. When `SIGHU
 
 The `SIGUSR1` signal is used to refresh the system-level side effects of the configuration without reading from disk, such as performing log file rotation and managing worker or timer processes (for example health checks and periodic maintenance watchers). It applies changes made directly to shared memory (via `conf set`) to the running instance. Use this to ensure log files are correctly handled by external tools like `logrotate` or to trigger dynamic process management.
 
-The child processes support `SIGQUIT` as a mechanism to shutdown. This will not shutdown the pool itself.
+The child processes support `SIGQUIT` as a mechanism to shutdown. This will not shutdown the pool itself. In addition, child processes support `SIGUSR1` to pause traffic and `SIGUSR2` to resume traffic.
 
 It should not be needed to use `SIGKILL` for [**pgagroal**](https://github.com/pgagroal/pgagroal). Please, consider using `SIGABRT` instead, and share the
 core dump and debug logs with the [**pgagroal**](https://github.com/pgagroal/pgagroal) community.

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -23,7 +23,7 @@ Available options are the following ones:
 -P, --password PASSWORD  Set the password
 -L, --logfile FILE       Set the log file
 -F, --format  text|json  Set the output format
--T, --timeout DURATION   Deadline for 'shutdown [gracefully]' / 'flush [gracefully]'.
+-T, --timeout DURATION   Deadline for 'shutdown [gracefully]', 'flush [gracefully]', and 'pause [gracefully]'.
                          DURATION is a non-negative number with an optional unit suffix:
                          's' (seconds, default), 'm' (minutes), 'h' (hours),
                          'd' (days), 'w' (weeks). E.g. '30', '30s', '5m', '1h', '2d', '1w'.
@@ -145,6 +145,47 @@ Example
 
 ```
 pgagroal-cli disable
+```
+
+### pause
+Pauses traffic at the pooler for a server or all servers.
+
+It supports the following operating policies:
+- `gracefully` (the default) refuses new clients, evicts idle backend connections, and waits until all active sessions finish naturally;
+- `all` actively terminates backend queries (using PostgreSQL cancel requests) but preserves the client sockets. Backends are reauthenticated on resume.
+
+A deadline may be bound to a graceful pause via the global `-T, --timeout DURATION` option. If the deadline expires, pgagroal escalates to `pause all`. When `--timeout` is omitted, pgagroal falls back to the `flush_timeout` value from `pgagroal.conf`.
+
+Command
+
+```
+pgagroal-cli pause [gracefully|all] [<server>|*]
+pgagroal-cli pause [gracefully] [<server>|*] --timeout <DURATION>
+```
+
+Example
+
+```
+pgagroal-cli pause
+pgagroal-cli pause gracefully my_server
+pgagroal-cli pause all
+pgagroal-cli pause --timeout 30
+```
+
+### resume
+Resumes traffic at the pooler for a previously paused server (or all servers).
+
+Command
+
+```
+pgagroal-cli resume [<server>|*]
+```
+
+Example
+
+```
+pgagroal-cli resume
+pgagroal-cli resume my_server
 ```
 
 ### shutdown

--- a/doc/PROMETHEUS.md
+++ b/doc/PROMETHEUS.md
@@ -28,6 +28,26 @@ The mode of pipeline
 
 The number of errors for servers
 
+**pgagroal_server_pause_total**
+
+The number of successful pause operations per server
+
+**pgagroal_server_resume_total**
+
+The number of successful resume operations per server
+
+**pgagroal_server_pause_state**
+
+The pause state of the server (0 = running, 1 = paused)
+
+**pgagroal_pause_pending_active_connections**
+
+The number of slots still in use on a paused server (0 when fully drained)
+
+**pgagroal_server_last_paused_timestamp**
+
+The Unix time when the server was paused (0 if running). The pause duration is derived in PromQL as `time() - pgagroal_server_last_paused_timestamp`
+
 **pgagroal_logging_info**
 
 The number of INFO logging statements

--- a/doc/man/pgagroal-cli.1.rst
+++ b/doc/man/pgagroal-cli.1.rst
@@ -49,7 +49,7 @@ OPTIONS
   Encrypt the wire protocol
 
 -T, --timeout DURATION
-  Deadline for ``shutdown [gracefully]`` and ``flush [gracefully]``.
+  Deadline for ``shutdown [gracefully]``, ``flush [gracefully]``, and ``pause [gracefully]``.
   ``DURATION`` is a non-negative number with an optional case-insensitive unit
   suffix: ``s`` (seconds, default), ``m`` (minutes), ``h`` (hours), ``d`` (days),
   ``w`` (weeks). Examples: ``30``, ``30s``, ``5m``, ``1h``, ``2d``, ``1w``.
@@ -92,6 +92,17 @@ enable [database]
 
 disable [database]
   Disable the specified database, or all databases if not specified
+
+pause [mode] [server]
+  Pauses traffic at the pooler for a server or all servers. The [mode] can be:
+    - 'gracefully' (default): refuses new clients, evicts idle backend connections, and waits until all active sessions finish naturally.
+    - 'all': actively terminates backend queries but preserves client sockets. Backends are reauthenticated on resume.
+
+  A graceful pause can be bounded with ``-T, --timeout DURATION``; on expiry pgagroal escalates to ``pause all``.
+
+resume [server]
+  Resumes traffic at the pooler for a previously paused server (or all servers).
+  If paused with ``all`` mode, pgagroal attempts to transparently re-authenticate the backend connection using passwords stored in the pooler configuration.
 
 shutdown [mode]
   Stops pgagroal pooler. The [mode] can be:

--- a/doc/man/pgagroal.conf.5.rst
+++ b/doc/man/pgagroal.conf.5.rst
@@ -128,10 +128,10 @@ flush_timeout
   If this value is specified without units, it is taken as seconds.
   It supports the following units as suffixes: 'S' for seconds (default), 'M' for minutes, 'H' for hours,
   'D' for days, and 'W' for weeks.
-  Used as the default deadline for graceful ``pgagroal-cli flush`` and ``pgagroal-cli shutdown`` operations
+  Used as the default deadline for graceful ``pgagroal-cli flush``, ``pgagroal-cli shutdown``, and ``pgagroal-cli pause`` operations
   when ``-T, --timeout`` is omitted on the CLI; this timeout exists to bound the wait for long-running
   transactions still holding pooled connections. On expiry a graceful flush escalates to ``flush all`` for the
-  targeted database and a graceful shutdown forces an immediate shutdown.
+  targeted database, a graceful shutdown forces an immediate shutdown, and a graceful pause escalates to ``pause all``.
   (disable = 0) Default is 60
 
 validation

--- a/src/cli.c
+++ b/src/cli.c
@@ -62,6 +62,8 @@
 #define COMMAND_CLEAR_SERVER   "clear-server"
 #define COMMAND_DISABLEDB      "disable-db"
 #define COMMAND_ENABLEDB       "enable-db"
+#define COMMAND_PAUSE          "pause"
+#define COMMAND_RESUME         "resume"
 #define COMMAND_FLUSH          "flush"
 #define COMMAND_GRACEFULLY     "shutdown-gracefully"
 #define COMMAND_PING           "ping"
@@ -87,6 +89,8 @@ static void help_clear(void);
 static void help_conf(void);
 static void help_disabledb(void);
 static void help_enabledb(void);
+static void help_pause(void);
+static void help_resume(void);
 static void help_flush(void);
 static void help_ping(void);
 static void help_shutdown(void);
@@ -100,6 +104,8 @@ static int conf_set(SSL* ssl, int socket, char* config_key, char* config_value, 
 static int details(SSL* ssl, int socket, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int disabledb(SSL* ssl, int socket, char* database, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int enabledb(SSL* ssl, int socket, char* database, uint8_t compression, uint8_t encryption, int32_t output_format);
+static int pause_cmd(SSL* ssl, int socket, int32_t mode, char* server, int64_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format);
+static int resume_cmd(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int flush(SSL* ssl, int socket, int32_t mode, char* database, int64_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int gracefully(SSL* ssl, int socket, int64_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int pgagroal_shutdown(SSL* ssl, int socket, uint8_t compression, uint8_t encryption, int32_t output_format);
@@ -161,6 +167,45 @@ const struct pgagroal_command command_table[] = {
       .default_argument = "all",
       .deprecated = false,
       .log_message = "<disable> [%s]",
+   },
+   {
+      .command = "pause",
+      .subcommand = "",
+      .accepted_argument_count = {0, 1},
+      .action = MANAGEMENT_PAUSE,
+      .mode = PAUSE_MODE_GRACEFULLY,
+      .default_argument = "*",
+      .deprecated = false,
+      .log_message = "<pause gracefully> [%s]",
+   },
+   {
+      .command = "pause",
+      .subcommand = "gracefully",
+      .accepted_argument_count = {0, 1},
+      .action = MANAGEMENT_PAUSE,
+      .mode = PAUSE_MODE_GRACEFULLY,
+      .default_argument = "*",
+      .deprecated = false,
+      .log_message = "<pause gracefully> [%s]",
+   },
+   {
+      .command = "pause",
+      .subcommand = "all",
+      .accepted_argument_count = {0, 1},
+      .action = MANAGEMENT_PAUSE,
+      .mode = PAUSE_MODE_ALL,
+      .default_argument = "*",
+      .deprecated = false,
+      .log_message = "<pause all> [%s]",
+   },
+   {
+      .command = "resume",
+      .subcommand = "",
+      .accepted_argument_count = {0, 1},
+      .action = MANAGEMENT_RESUME,
+      .default_argument = "*",
+      .deprecated = false,
+      .log_message = "<resume> [%s]",
    },
    {
       .command = "shutdown",
@@ -345,8 +390,8 @@ usage(void)
    printf("  -C, --compress none|gz|zstd|lz4|bz2          Compress the wire protocol\n");
    printf("  -E, --encrypt none|aes|aes256|aes192|aes128  Encrypt the wire protocol using AES-GCM\n");
    printf("                |aes256gcm|aes192gcm|aes128gcm (Note: non-GCM AES modes are not supported)\n");
-   printf("  -T, --timeout DURATION                       Deadline for 'shutdown [gracefully]' and\n");
-   printf("                                                 'flush [gracefully]'. DURATION is a non-negative\n");
+   printf("  -T, --timeout DURATION                       Deadline for 'shutdown [gracefully]',\n");
+   printf("                                                 'flush [gracefully]', and 'pause [gracefully]'. DURATION is a non-negative\n");
    printf("                                                 number with an optional unit suffix:\n");
    printf("                                                 s (seconds, default), m (minutes), h (hours),\n");
    printf("                                                 d (days), w (weeks). E.g. '30', '30s', '5m',\n");
@@ -370,6 +415,10 @@ usage(void)
    printf("  ping                     Verifies if pgagroal is up and checks PostgreSQL server connectivity\n");
    printf("  enable   [database]      Enables the specified databases (or all databases)\n");
    printf("  disable  [database]      Disables the specified databases (or all databases)\n");
+   printf("  pause    [server]        Pauses the specified servers (or Pause all servers)\n");
+   printf("                           With '--timeout DURATION' on 'gracefully', pgagroal forces an\n");
+   printf("                           immediate pause (all) on expiry.\n");
+   printf("  resume   [server]        Resumes the specified servers (or Resume all servers)\n");
    printf("  shutdown [mode]          Stops pgagroal pooler. The [mode] can be:\n");
    printf("                           - 'gracefully' (default) waits for active connections to quit\n");
    printf("                           - 'immediate' forces connections to close and terminate\n");
@@ -799,6 +848,14 @@ username:
    {
       exit_code = disabledb(s_ssl, socket, parsed.args[0], compression, encryption, output_format);
    }
+   else if (parsed.cmd->action == MANAGEMENT_PAUSE)
+   {
+      exit_code = pause_cmd(s_ssl, socket, parsed.cmd->mode, parsed.args[0], timeout, compression, encryption, output_format);
+   }
+   else if (parsed.cmd->action == MANAGEMENT_RESUME)
+   {
+      exit_code = resume_cmd(s_ssl, socket, parsed.args[0], compression, encryption, output_format);
+   }
    else if (parsed.cmd->action == MANAGEMENT_GRACEFULLY)
    {
       exit_code = gracefully(s_ssl, socket, timeout, compression, encryption, output_format);
@@ -942,6 +999,35 @@ help_enabledb(void)
 }
 
 static void
+help_pause(void)
+{
+   printf("Pause traffic at the pooler for a server or all servers\n");
+   printf("  pgagroal-cli pause [gracefully|all] [<server>]\n");
+   printf("  pgagroal-cli pause [gracefully] [<server>] --timeout <DURATION>\n");
+   printf("    '--timeout' bounds a graceful pause; DURATION overrides 'flush_timeout' from pgagroal.conf.\n");
+   printf("    DURATION is a non-negative number with an optional unit suffix: s (seconds, default), m (minutes),\n");
+   printf("    h (hours), d (days), w (weeks); e.g. '30', '30s', '5m', '1h', '2d', '1w'.\n");
+   printf("    Omit '--timeout' to fall back to 'flush_timeout' from pgagroal.conf. '--timeout 0' explicitly\n");
+   printf("    disables the timer (pause runs unbounded), same meaning as 'flush_timeout = 0' in the conf.\n");
+   printf("    When 'flush_timeout' is not set in pgagroal.conf, the built-in default (60s) applies.\n");
+   printf("    On expiry remaining marked connections are terminated (pause all). If no client currently\n");
+   printf("    holds a connection, the pause completes immediately and no timer is armed.\n");
+   printf("\n");
+   printf("Policies:\n");
+   printf("  gracefully  Refuse new clients, evict idle backend connections,\n");
+   printf("              wait until all active sessions finish naturally (default).\n");
+   printf("  all         As gracefully, plus cancel active sessions. Client sockets\n");
+   printf("              are preserved; backends are reauthenticated on resume.\n");
+}
+
+static void
+help_resume(void)
+{
+   printf("Resume traffic at the pooler for a server or all servers\n");
+   printf("  pgagroal-cli resume [<server>]\n");
+}
+
+static void
 help_conf(void)
 {
    printf("Manage the configuration\n");
@@ -1004,6 +1090,14 @@ display_helper(char* command)
    else if (!strcmp(command, COMMAND_ENABLEDB))
    {
       help_enabledb();
+   }
+   else if (!strcmp(command, COMMAND_PAUSE))
+   {
+      help_pause();
+   }
+   else if (!strcmp(command, COMMAND_RESUME))
+   {
+      help_resume();
    }
    else if (!strcmp(command, COMMAND_FLUSH))
    {
@@ -1080,6 +1174,46 @@ static int
 disabledb(SSL* ssl, int socket, char* database, uint8_t compression, uint8_t encryption, int32_t output_format)
 {
    if (pgagroal_management_request_disabledb(ssl, socket, database, compression, encryption, output_format))
+   {
+      goto error;
+   }
+
+   if (process_result(ssl, socket, output_format))
+   {
+      goto error;
+   }
+
+   return 0;
+
+error:
+
+   return 1;
+}
+
+static int
+pause_cmd(SSL* ssl, int socket, int32_t mode, char* server, int64_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format)
+{
+   if (pgagroal_management_request_pause(ssl, socket, mode, server, timeout, compression, encryption, output_format))
+   {
+      goto error;
+   }
+
+   if (process_result(ssl, socket, output_format))
+   {
+      goto error;
+   }
+
+   return 0;
+
+error:
+
+   return 1;
+}
+
+static int
+resume_cmd(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format)
+{
+   if (pgagroal_management_request_resume(ssl, socket, server, compression, encryption, output_format))
    {
       goto error;
    }
@@ -2055,6 +2189,12 @@ translate_command(int32_t cmd_code)
          break;
       case MANAGEMENT_ENABLEDB:
          command_output = pgagroal_append(command_output, COMMAND_ENABLEDB);
+         break;
+      case MANAGEMENT_PAUSE:
+         command_output = pgagroal_append(command_output, COMMAND_PAUSE);
+         break;
+      case MANAGEMENT_RESUME:
+         command_output = pgagroal_append(command_output, COMMAND_RESUME);
          break;
       case MANAGEMENT_FLUSH:
          command_output = pgagroal_append(command_output, COMMAND_FLUSH);

--- a/src/include/ev.h
+++ b/src/include/ev.h
@@ -147,6 +147,7 @@ struct io_watcher
       int __fds[2];
    } fds;                                  /**< Set of file descriptors used for I/O */
    bool ssl;                               /**< Indicates if SSL/TLS is used on this connection. */
+   bool paused;                            /**< Indicates if I/O is paused. */
    struct message* msg;                    /**< Per-watcher message buffer to avoid global state races */
    void (*cb)(struct io_watcher* watcher); /**< Event callback. */
 };
@@ -322,6 +323,36 @@ pgagroal_io_start(struct io_watcher* watcher);
  */
 int
 pgagroal_io_stop(struct io_watcher* watcher);
+
+/**
+ * Pause the watcher for an IO event in the event loop.
+ *
+ * Unlike pgagroal_io_stop, this is intended to be reversible via
+ * pgagroal_io_resume. The watcher is marked as paused and removed from
+ * the active events list.
+ *
+ * For epoll and kqueue backends, the file descriptor is removed from
+ * the polling interest list but remains open.
+ * For io_uring, an asynchronous cancel request is submitted for the watcher.
+ *
+ * @param watcher Pointer to the io event watcher struct
+ * @return Return code
+ */
+int
+pgagroal_io_pause(struct io_watcher* watcher);
+
+/**
+ * Resume a paused watcher for an IO event in the event loop.
+ *
+ * This reverses the effect of pgagroal_io_pause. The watcher is marked as
+ * unpaused, re-added to the active events list, and the underlying polling
+ * mechanism is instructed to resume monitoring the file descriptor.
+ *
+ * @param watcher Pointer to the io event watcher struct
+ * @return Return code
+ */
+int
+pgagroal_io_resume(struct io_watcher* watcher);
 
 /**
  * Initialize the watcher for periodic timeout events

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -92,6 +92,8 @@ extern "C" {
 #define MANAGEMENT_UPDATE_USER     21
 #define MANAGEMENT_REMOVE_USER     22
 #define MANAGEMENT_LIST_USERS      23
+#define MANAGEMENT_PAUSE           24
+#define MANAGEMENT_RESUME          25
 /**
  * Management arguments
  */
@@ -107,6 +109,11 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_DATABASE            "Database"
 #define MANAGEMENT_ARGUMENT_DATABASES           "Databases"
 #define MANAGEMENT_ARGUMENT_ENABLED             "Enabled"
+#define MANAGEMENT_ARGUMENT_RESUMED             "Resumed"
+#define MANAGEMENT_ARGUMENT_PAUSED              "Paused"
+#define MANAGEMENT_ARGUMENT_ALL_PAUSED          "AllPaused"
+#define MANAGEMENT_ARGUMENT_LAST_PAUSED         "LastPaused"
+#define MANAGEMENT_ARGUMENT_LAST_RESUMED        "LastResumed"
 #define MANAGEMENT_ARGUMENT_ENCRYPTION          "Encryption"
 #define MANAGEMENT_ARGUMENT_ERROR               "Error"
 #define MANAGEMENT_ARGUMENT_FD                  "FD"
@@ -151,6 +158,12 @@ extern "C" {
 #define MANAGEMENT_ERROR_FLUSH_NOFORK                       200
 #define MANAGEMENT_ERROR_FLUSH_NETWORK                      201
 
+#define MANAGEMENT_ERROR_PAUSE_NOFORK                       210
+#define MANAGEMENT_ERROR_PAUSE_UNKNOWN_SERVER               211
+
+#define MANAGEMENT_ERROR_RESUME_NOFORK                      212
+#define MANAGEMENT_ERROR_RESUME_UNKNOWN_SERVER              213
+
 #define MANAGEMENT_ERROR_STATUS_NOFORK                      700
 #define MANAGEMENT_ERROR_STATUS_NETWORK                     701
 
@@ -193,6 +206,15 @@ extern "C" {
  */
 int
 pgagroal_management_create_header(int32_t command, uint8_t compression, uint8_t encryption, int32_t output_format, struct json** json);
+
+/**
+ * Format a time_t value as a management timestamp (YYYYMMDDHHMMSS).
+ * @param t The time to format (0 yields an empty string)
+ * @param buffer The output buffer
+ * @param size The size of the output buffer
+ */
+void
+pgagroal_management_format_timestamp(time_t t, char* buffer, size_t size);
 
 /**
  * Create request for management command
@@ -267,6 +289,37 @@ pgagroal_management_request_enabledb(SSL* ssl, int socket, char* database, uint8
  */
 int
 pgagroal_management_request_disabledb(SSL* ssl, int socket, char* database, uint8_t compression, uint8_t encryption, int32_t output_format);
+
+/**
+ * Management operation: Pause server
+ * @param ssl The SSL connection
+ * @param socket The socket descriptor
+ * @param mode The pause policy (PAUSE_MODE_GRACEFULLY  / _ALL)
+ * @param server The server (optional, can be NULL or "*")
+ * @param timeout Seconds to wait before forcing pause of remaining active sessions.
+ *                Negative (e.g. -1) means "use 'flush_timeout' from pgagroal.conf";
+ *                zero (0) means "disable timeout (wait forever)".
+ *                Only applies to PAUSE_MODE_GRACEFULLY.
+ * @param compression The compression
+ * @param encryption The encryption
+ * @param output_format The output format
+ * @return 0 on success, otherwise 1
+ */
+int
+pgagroal_management_request_pause(SSL* ssl, int socket, int32_t mode, char* server, int64_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format);
+
+/**
+ * Management operation: Resume server
+ * @param ssl The SSL connection
+ * @param socket The socket descriptor
+ * @param server The server
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol (None or *_GCM)
+ * @param output_format The output format
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_management_request_resume(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format);
 
 /**
  * Management operation: Gracefully

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -92,6 +92,8 @@ extern "C" {
 #define MANAGEMENT_UPDATE_USER     21
 #define MANAGEMENT_REMOVE_USER     22
 #define MANAGEMENT_LIST_USERS      23
+#define MANAGEMENT_PAUSE           24
+#define MANAGEMENT_RESUME          25
 /**
  * Management arguments
  */
@@ -107,6 +109,11 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_DATABASE            "Database"
 #define MANAGEMENT_ARGUMENT_DATABASES           "Databases"
 #define MANAGEMENT_ARGUMENT_ENABLED             "Enabled"
+#define MANAGEMENT_ARGUMENT_RESUMED             "Resumed"
+#define MANAGEMENT_ARGUMENT_PAUSED              "Paused"
+#define MANAGEMENT_ARGUMENT_ALL_PAUSED          "AllPaused"
+#define MANAGEMENT_ARGUMENT_LAST_PAUSED         "LastPaused"
+#define MANAGEMENT_ARGUMENT_LAST_RESUMED        "LastResumed"
 #define MANAGEMENT_ARGUMENT_ENCRYPTION          "Encryption"
 #define MANAGEMENT_ARGUMENT_ERROR               "Error"
 #define MANAGEMENT_ARGUMENT_FD                  "FD"
@@ -157,6 +164,12 @@ extern "C" {
 #define MANAGEMENT_ERROR_FLUSH_NOFORK                       200
 #define MANAGEMENT_ERROR_FLUSH_NETWORK                      201
 
+#define MANAGEMENT_ERROR_PAUSE_NOFORK                       210
+#define MANAGEMENT_ERROR_PAUSE_UNKNOWN_SERVER               211
+
+#define MANAGEMENT_ERROR_RESUME_NOFORK                      212
+#define MANAGEMENT_ERROR_RESUME_UNKNOWN_SERVER              213
+
 #define MANAGEMENT_ERROR_STATUS_NOFORK                      700
 #define MANAGEMENT_ERROR_STATUS_NETWORK                     701
 
@@ -199,6 +212,15 @@ extern "C" {
  */
 int
 pgagroal_management_create_header(int32_t command, uint8_t compression, uint8_t encryption, int32_t output_format, struct json** json);
+
+/**
+ * Format a time_t value as a management timestamp (YYYYMMDDHHMMSS).
+ * @param t The time to format (0 yields an empty string)
+ * @param buffer The output buffer
+ * @param size The size of the output buffer
+ */
+void
+pgagroal_management_format_timestamp(time_t t, char* buffer, size_t size);
 
 /**
  * Create request for management command
@@ -273,6 +295,37 @@ pgagroal_management_request_enabledb(SSL* ssl, int socket, char* database, uint8
  */
 int
 pgagroal_management_request_disabledb(SSL* ssl, int socket, char* database, uint8_t compression, uint8_t encryption, int32_t output_format);
+
+/**
+ * Management operation: Pause server
+ * @param ssl The SSL connection
+ * @param socket The socket descriptor
+ * @param mode The pause policy (PAUSE_MODE_GRACEFULLY  / _ALL)
+ * @param server The server (optional, can be NULL or "*")
+ * @param timeout Seconds to wait before forcing pause of remaining active sessions.
+ *                Negative (e.g. -1) means "use 'flush_timeout' from pgagroal.conf";
+ *                zero (0) means "disable timeout (wait forever)".
+ *                Only applies to PAUSE_MODE_GRACEFULLY.
+ * @param compression The compression
+ * @param encryption The encryption
+ * @param output_format The output format
+ * @return 0 on success, otherwise 1
+ */
+int
+pgagroal_management_request_pause(SSL* ssl, int socket, int32_t mode, char* server, int64_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format);
+
+/**
+ * Management operation: Resume server
+ * @param ssl The SSL connection
+ * @param socket The socket descriptor
+ * @param server The server
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol (None or *_GCM)
+ * @param output_format The output format
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgagroal_management_request_resume(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format);
 
 /**
  * Management operation: Gracefully

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -162,6 +162,9 @@ extern "C" {
 #define FLUSH_GRACEFULLY               1
 #define FLUSH_ALL                      2
 
+#define PAUSE_MODE_GRACEFULLY          0
+#define PAUSE_MODE_ALL                 1
+
 #define VALIDATION_OFF                 0
 #define VALIDATION_FOREGROUND          1
 #define VALIDATION_BACKGROUND          2
@@ -400,6 +403,9 @@ struct server
    unsigned int failures;        /**< The number of failures */
    atomic_schar auth_type;       /**< The authentication type used for health check */
    int lineno;                   /**< The line number within the configuration file */
+   bool paused;                  /**< The server state */
+   time_t last_paused;           /**< The last time the server paused */
+   time_t last_resumed;          /**< The last time the server resumed */
 } __attribute__((aligned(64)));
 
 #define FOREACH_SERVER for (int i = 0; i < config->number_of_servers; i++)
@@ -620,6 +626,8 @@ struct main_prometheus
    atomic_ullong network_received; /**< The bytes received from servers */
 
    atomic_ulong server_error[NUMBER_OF_SERVERS];          /**< The number of errors for a server */
+   atomic_ulong server_pause_total[NUMBER_OF_SERVERS];    /**< Successful pause operations per server */
+   atomic_ulong server_resume_total[NUMBER_OF_SERVERS];   /**< Successful resume operations per server */
    atomic_ulong failed_servers;                           /**< The number of failed servers */
    struct certificate_metrics cert_metrics;               /**< TLS certificate metrics */
    struct prometheus_connection prometheus_connections[]; /**< The number of prometheus connections (FMA) */
@@ -706,7 +714,8 @@ struct main_configuration
    bool all_disabled;                                      /**< Are all databases disabled */
    char disabled[NUMBER_OF_DISABLED][MAX_DATABASE_LENGTH]; /**< Which databases are disabled */
 
-   int pipeline; /**< The pipeline type */
+   bool all_paused; /**< Are all servers paused */
+   int pipeline;    /**< The pipeline type */
 
    bool failover;                            /**< Is failover enabled */
    char failover_script[MISC_LENGTH];        /**< The failover script */
@@ -780,6 +789,16 @@ struct flush_timeout_slot
    bool in_use;                        /**< Is timeout slot in use */
    char database[MAX_DATABASE_LENGTH]; /**< The database name */
    struct timespec expires_at;         /**< Slot expires at */
+};
+
+/** @struct pause_timeout_slot
+ * Defines a timeout for each server
+ */
+struct pause_timeout_slot
+{
+   bool in_use;
+   char server[MISC_LENGTH];
+   struct timespec expires_at; /* CLOCK_MONOTONIC */
 };
 
 #ifdef __cplusplus

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -170,6 +170,13 @@ extern "C" {
 #define FLUSH_GRACEFULLY                               1
 #define FLUSH_ALL                                      2
 
+#define PAUSE_MODE_GRACEFULLY                          0
+#define PAUSE_MODE_ALL                                 1
+
+#define VALIDATION_OFF                                 0
+#define VALIDATION_FOREGROUND                          1
+#define VALIDATION_BACKGROUND                          2
+
 #define VALIDATION_OFF                                 0
 #define VALIDATION_FOREGROUND                          1
 #define VALIDATION_BACKGROUND                          2
@@ -414,6 +421,10 @@ struct server
    unsigned int failures;         /**< The number of failures */
    atomic_schar auth_type;        /**< The authentication type used for health check */
    int lineno;                    /**< The line number within the configuration file */
+   bool paused;                   /**< The server state */
+   time_t last_paused;            /**< The last time the server paused */
+   time_t last_resumed;           /**< The last time the server resumed */
+
 } __attribute__((aligned(64)));
 
 #define FOREACH_SERVER for (int i = 0; i < config->number_of_servers; i++)
@@ -635,6 +646,8 @@ struct main_prometheus
    atomic_ullong network_received; /**< The bytes received from servers */
 
    atomic_ulong server_error[NUMBER_OF_SERVERS];          /**< The number of errors for a server */
+   atomic_ulong server_pause_total[NUMBER_OF_SERVERS];    /**< Successful pause operations per server */
+   atomic_ulong server_resume_total[NUMBER_OF_SERVERS];   /**< Successful resume operations per server */
    atomic_ulong failed_servers;                           /**< The number of failed servers */
    struct certificate_metrics cert_metrics;               /**< TLS certificate metrics */
    struct prometheus_connection prometheus_connections[]; /**< The number of prometheus connections (FMA) */
@@ -721,7 +734,8 @@ struct main_configuration
    bool all_disabled;                                      /**< Are all databases disabled */
    char disabled[NUMBER_OF_DISABLED][MAX_DATABASE_LENGTH]; /**< Which databases are disabled */
 
-   int pipeline; /**< The pipeline type */
+   bool all_paused; /**< Are all servers paused */
+   int pipeline;    /**< The pipeline type */
 
    bool failover;                            /**< Is failover enabled */
    char failover_script[MISC_LENGTH];        /**< The failover script */
@@ -797,6 +811,16 @@ struct flush_timeout_slot
    bool in_use;                        /**< Is timeout slot in use */
    char database[MAX_DATABASE_LENGTH]; /**< The database name */
    struct timespec expires_at;         /**< Slot expires at */
+};
+
+/** @struct pause_timeout_slot
+ * Defines a timeout for each server
+ */
+struct pause_timeout_slot
+{
+   bool in_use;
+   char server[MISC_LENGTH];
+   struct timespec expires_at; /* CLOCK_MONOTONIC */
 };
 
 #ifdef __cplusplus

--- a/src/include/pool.h
+++ b/src/include/pool.h
@@ -131,6 +131,42 @@ void
 pgagroal_request_flush(SSL* ssl, int client_fd, uint8_t compression, uint8_t encryption, struct json* payload);
 
 /**
+ * @param mode One of PAUSE_MODE_GRACEFULLY / PAUSE_MODE_ALL
+ * @param server Server name, or "*" / NULL for all servers
+ */
+void
+pgagroal_pause(int mode, char* server);
+
+/**
+ * Resume a paused server or entire pool
+ * @param server Server name, or "*" / NULL for all servers
+ */
+void
+pgagroal_resume(char* server);
+
+/**
+ * @param ssl The SSL connection
+ * @param client_fd The client
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol
+ * @param payload The payload
+ */
+void
+pgagroal_request_pause(SSL* ssl, int client_fd, uint8_t compression, uint8_t encryption, struct json* payload);
+
+/**
+ * Resume handler for management child process.
+ * Resumes the server/pool, sends the response, and exits.
+ * @param ssl The SSL connection
+ * @param client_fd The client
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol
+ * @param payload The payload
+ */
+void
+pgagroal_request_resume(SSL* ssl, int client_fd, uint8_t compression, uint8_t encryption, struct json* payload);
+
+/**
  * Prefill the pool
  * @param initial Use initial size
  */

--- a/src/include/prometheus.h
+++ b/src/include/prometheus.h
@@ -326,6 +326,20 @@ void
 pgagroal_prometheus_server_error(int server);
 
 /**
+ * Record a successful pause for a server (management pause path)
+ * @param server The server index
+ */
+void
+pgagroal_prometheus_server_pause(int server);
+
+/**
+ * Record a successful resume for a server (management resume path)
+ * @param server The server index
+ */
+void
+pgagroal_prometheus_server_resume(int server);
+
+/**
  * Count failed servers
  */
 void

--- a/src/include/security.h
+++ b/src/include/security.h
@@ -71,6 +71,15 @@ int
 pgagroal_prefill_auth(char* username, char* password, char* database, int* slot, SSL** server_ssl);
 
 /**
+ * @param slot The slot to reauth (must currently be in STATE_PAUSED with
+ *             username, database and server fields populated)
+ * @param server_ssl The server SSL context (output)
+ * @return AUTH_SUCCESS upon success, AUTH_ERROR otherwise
+ */
+int
+pgagroal_reauth_slot(int slot, SSL** server_ssl);
+
+/**
  * Authenticate a remote management user
  * @param client_fd The descriptor
  * @param address The client address

--- a/src/include/worker.h
+++ b/src/include/worker.h
@@ -45,6 +45,8 @@ extern "C" {
 #define WORKER_SERVER_FAILURE 4
 #define WORKER_SERVER_FATAL   5
 #define WORKER_FAILOVER       6
+#define WORKER_PAUSED         7
+#define WORKER_RESUME         8
 
 /** @struct worker_io
  * The worker structure for each IO event

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -316,6 +316,9 @@ pgagroal_read_configuration(void* shm, char* filename, bool emit_warnings)
                memcpy(&srv.name, &section, strlen(section));
                srv.lineno = lineno;
                srv.valid = true;
+               srv.paused = false;
+               srv.last_paused = 0;
+               srv.last_resumed = 0;
                idx_server++;
             }
          }
@@ -3988,6 +3991,9 @@ copy_server(struct server* dst, struct server* src)
    int version;
    int minor_version;
    char system_identifier[sizeof(dst->system_identifier)];
+   bool paused;
+   time_t last_paused;
+   time_t last_resumed;
 
    // check the server cloned "seems" the same
    if (is_same_server(dst, src))
@@ -3999,6 +4005,9 @@ copy_server(struct server* dst, struct server* src)
       version = dst->version;
       minor_version = dst->minor_version;
       memcpy(system_identifier, dst->system_identifier, sizeof(system_identifier));
+      paused = dst->paused;
+      last_paused = dst->last_paused;
+      last_resumed = dst->last_resumed;
    }
    else
    {
@@ -4009,6 +4018,9 @@ copy_server(struct server* dst, struct server* src)
       version = 0;
       minor_version = 0;
       memset(system_identifier, 0, sizeof(system_identifier));
+      paused = false;
+      last_paused = 0;
+      last_resumed = 0;
    }
 
    memset(dst, 0, sizeof(struct server));
@@ -4030,6 +4042,11 @@ copy_server(struct server* dst, struct server* src)
    dst->failures = failures;
    atomic_init(&dst->auth_type, auth_type);
    dst->lineno = src->lineno;
+
+   /* Preserve pause bookkeeping across configuration reloads */
+   dst->paused = paused;
+   dst->last_paused = last_paused;
+   dst->last_resumed = last_resumed;
 }
 
 static void

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -320,6 +320,9 @@ pgagroal_read_configuration(void* shm, char* filename, bool emit_warnings)
                memcpy(&srv.name, &section, strlen(section));
                srv.lineno = lineno;
                srv.valid = true;
+               srv.paused = false;
+               srv.last_paused = 0;
+               srv.last_resumed = 0;
                srv.channel_binding = CHANNEL_BINDING_PREFER;
                idx_server++;
             }
@@ -4053,6 +4056,9 @@ copy_server(struct server* dst, struct server* src)
    int version;
    int minor_version;
    char system_identifier[sizeof(dst->system_identifier)];
+   bool paused;
+   time_t last_paused;
+   time_t last_resumed;
 
    // check the server cloned "seems" the same
    if (is_same_server(dst, src))
@@ -4064,6 +4070,9 @@ copy_server(struct server* dst, struct server* src)
       version = dst->version;
       minor_version = dst->minor_version;
       memcpy(system_identifier, dst->system_identifier, sizeof(system_identifier));
+      paused = dst->paused;
+      last_paused = dst->last_paused;
+      last_resumed = dst->last_resumed;
    }
    else
    {
@@ -4074,6 +4083,9 @@ copy_server(struct server* dst, struct server* src)
       version = 0;
       minor_version = 0;
       memset(system_identifier, 0, sizeof(system_identifier));
+      paused = false;
+      last_paused = 0;
+      last_resumed = 0;
    }
 
    memset(dst, 0, sizeof(struct server));
@@ -4096,6 +4108,11 @@ copy_server(struct server* dst, struct server* src)
    dst->failures = failures;
    atomic_init(&dst->auth_type, auth_type);
    dst->lineno = src->lineno;
+
+   /* Preserve pause bookkeeping across configuration reloads */
+   dst->paused = paused;
+   dst->last_paused = last_paused;
+   dst->last_resumed = last_resumed;
 }
 
 static void

--- a/src/libpgagroal/ev.c
+++ b/src/libpgagroal/ev.c
@@ -71,6 +71,7 @@ static int (*loop_destroy)(void);
 
 static int (*io_start)(struct io_watcher*);
 static int (*io_stop)(struct io_watcher*);
+static int (*io_pause)(struct io_watcher*);
 
 static void signal_handler(int signum, siginfo_t* info, void* p);
 
@@ -92,6 +93,7 @@ static int ev_io_uring_setup_buffers(void);
 
 static int ev_io_uring_io_start(struct io_watcher*);
 static int ev_io_uring_io_stop(struct io_watcher*);
+static int ev_io_uring_io_pause(struct io_watcher*);
 
 static int ev_io_uring_periodic_init(struct periodic_watcher*, int64_t, int64_t);
 static int ev_io_uring_periodic_start(struct periodic_watcher*);
@@ -106,6 +108,7 @@ static int ev_epoll_handler(void*);
 
 static int ev_epoll_io_start(struct io_watcher*);
 static int ev_epoll_io_stop(struct io_watcher*);
+static int ev_epoll_io_pause(struct io_watcher*);
 static int ev_epoll_io_handler(struct io_watcher*);
 
 static int ev_epoll_periodic_init(struct periodic_watcher*, int64_t, int64_t);
@@ -123,6 +126,7 @@ static int ev_kqueue_handler(struct kevent*);
 
 static int ev_kqueue_io_start(struct io_watcher*);
 static int ev_kqueue_io_stop(struct io_watcher*);
+static int ev_kqueue_io_pause(struct io_watcher*);
 static int ev_kqueue_io_handler(struct kevent*);
 
 static int ev_kqueue_periodic_init(struct periodic_watcher*, int64_t, int64_t);
@@ -223,6 +227,7 @@ setup_ops(void)
       loop_start = ev_io_uring_loop;
       io_start = ev_io_uring_io_start;
       io_stop = ev_io_uring_io_stop;
+      io_pause = ev_io_uring_io_pause;
       periodic_init = ev_io_uring_periodic_init;
       periodic_start = ev_io_uring_periodic_start;
       periodic_stop = ev_io_uring_periodic_stop;
@@ -243,6 +248,7 @@ setup_ops(void)
       loop_start = ev_epoll_loop;
       io_start = ev_epoll_io_start;
       io_stop = ev_epoll_io_stop;
+      io_pause = ev_epoll_io_pause;
       periodic_init = ev_epoll_periodic_init;
       periodic_start = ev_epoll_periodic_start;
       periodic_stop = ev_epoll_periodic_stop;
@@ -257,6 +263,7 @@ setup_ops(void)
       loop_start = ev_kqueue_loop;
       io_start = ev_kqueue_io_start;
       io_stop = ev_kqueue_io_stop;
+      io_pause = ev_kqueue_io_pause;
       periodic_init = ev_kqueue_periodic_init;
       periodic_start = ev_kqueue_periodic_start;
       periodic_stop = ev_kqueue_periodic_stop;
@@ -435,6 +442,11 @@ pgagroal_event_loop_is_running(void)
 {
    return atomic_load(&loop->running);
 }
+bool
+pgagroal_io_paused(struct io_watcher* watcher)
+{
+   return watcher->paused;
+}
 
 int
 pgagroal_event_accept_init(struct io_watcher* watcher, int listen_fd, io_cb cb)
@@ -539,6 +551,74 @@ pgagroal_io_stop(struct io_watcher* watcher)
    return PGAGROAL_EVENT_RC_OK;
 }
 
+int
+pgagroal_io_pause(struct io_watcher* watcher)
+{
+   int found_idx = -1;
+
+   if (event_loop_called_from_child("pgagroal_io_pause"))
+      return PGAGROAL_EVENT_RC_OK;
+
+   assert(loop != NULL && watcher != NULL);
+
+   if (watcher->paused)
+   {
+      pgagroal_log_warn("pgagroal_io_pause: watcher already paused (fd rcv=%d)",
+                        watcher->fds.worker.rcv_fd);
+      return PGAGROAL_EVENT_RC_ERROR;
+   }
+
+   for (int i = 0; i < loop->events_nr; i++)
+   {
+      if (watcher == (struct io_watcher*)loop->events[i])
+      {
+         found_idx = i;
+         break;
+      }
+   }
+
+   if (found_idx < 0)
+   {
+      pgagroal_log_warn("pgagroal_io_pause: watcher not found (fd rcv=%d)",
+                        watcher->fds.worker.rcv_fd);
+      return PGAGROAL_EVENT_RC_ERROR;
+   }
+
+   int rc = io_pause(watcher);
+   if (rc != PGAGROAL_EVENT_RC_OK)
+   {
+      pgagroal_log_error("pgagroal_io_pause: io_pause failed %d", rc);
+      return rc;
+   }
+
+   watcher->paused = true;
+
+   for (int j = found_idx; j < loop->events_nr - 1; j++)
+      loop->events[j] = loop->events[j + 1];
+   loop->events_nr--;
+   loop->events[loop->events_nr] = NULL;
+
+   return PGAGROAL_EVENT_RC_OK;
+}
+int
+pgagroal_io_resume(struct io_watcher* watcher)
+{
+   if (event_loop_called_from_child("pgagroal_io_resume"))
+      return PGAGROAL_EVENT_RC_OK;
+
+   assert(loop != NULL && watcher != NULL);
+
+   if (!pgagroal_io_paused(watcher))
+   {
+      pgagroal_log_warn("pgagroal_io_resume: watcher not paused (fd rcv=%d)",
+                        watcher->fds.worker.rcv_fd);
+      return PGAGROAL_EVENT_RC_ERROR;
+   }
+
+   watcher->paused = false;
+
+   return pgagroal_io_start(watcher);
+}
 int
 pgagroal_periodic_init(struct periodic_watcher* watcher, periodic_cb cb,
                        int64_t msec, int64_t repeat_ms)
@@ -933,6 +1013,24 @@ ev_io_uring_io_stop(struct io_watcher* target)
 }
 
 static int
+ev_io_uring_io_pause(struct io_watcher* watcher)
+{
+   struct io_uring_sqe* sqe = io_uring_get_sqe(&loop->ring_rcv);
+   if (!sqe)
+   {
+      pgagroal_log_error("io_uring: no SQE available for cancel (fd=%d)",
+                         watcher->fds.worker.rcv_fd);
+      return PGAGROAL_EVENT_RC_ERROR;
+   }
+
+   io_uring_prep_cancel(sqe, (void*)watcher, 0);
+   io_uring_sqe_set_data(sqe, NULL);
+   io_uring_submit(&loop->ring_rcv);
+
+   return PGAGROAL_EVENT_RC_OK;
+}
+
+static int
 ev_io_uring_periodic_init(struct periodic_watcher* watcher, int64_t msec, int64_t repeat_ms)
 {
    watcher->repeat_ms = repeat_ms;
@@ -1187,6 +1285,7 @@ ev_io_uring_handler(struct io_uring_cqe* cqe)
          break;
       case PGAGROAL_EVENT_TYPE_WORKER:
          io = (struct io_watcher*)watcher;
+
          msg = pgagroal_get_watcher_message(io);
          if (cqe->res <= 0)
          {
@@ -1210,8 +1309,8 @@ ev_io_uring_handler(struct io_uring_cqe* cqe)
             rc = PGAGROAL_EVENT_RC_OK;
             io->cb(io);
 
-            /* Only rearm if loop is still running and connection is good */
-            if (pgagroal_event_loop_is_running())
+            /* Only rearm if loop is still running, connection is good, and not paused */
+            if (pgagroal_event_loop_is_running() && !pgagroal_io_paused(io))
             {
                ev_io_uring_io_start(io);
             }
@@ -1552,6 +1651,13 @@ ev_epoll_io_stop(struct io_watcher* watcher)
 }
 
 static int
+ev_epoll_io_pause(struct io_watcher* watcher)
+{
+   /* epoll DEL — fd stays open */
+   return ev_epoll_io_stop(watcher);
+}
+
+static int
 ev_epoll_io_handler(struct io_watcher* watcher)
 {
    int client_fd = -1;
@@ -1846,6 +1952,13 @@ ev_kqueue_io_stop(struct io_watcher* watcher)
    }
 
    return PGAGROAL_EVENT_RC_OK;
+}
+
+static int
+ev_kqueue_io_pause(struct io_watcher* watcher)
+{
+   /* kqueue EV_DELETE — fd stays open */
+   return ev_kqueue_io_stop(watcher);
 }
 
 static int

--- a/src/libpgagroal/ev.c
+++ b/src/libpgagroal/ev.c
@@ -71,6 +71,7 @@ static int (*loop_destroy)(void);
 
 static int (*io_start)(struct io_watcher*);
 static int (*io_stop)(struct io_watcher*);
+static int (*io_pause)(struct io_watcher*);
 
 static void signal_handler(int signum, siginfo_t* info, void* p);
 
@@ -92,6 +93,7 @@ static int ev_io_uring_setup_buffers(void);
 
 static int ev_io_uring_io_start(struct io_watcher*);
 static int ev_io_uring_io_stop(struct io_watcher*);
+static int ev_io_uring_io_pause(struct io_watcher*);
 
 static int ev_io_uring_periodic_init(struct periodic_watcher*, int64_t, int64_t);
 static int ev_io_uring_periodic_start(struct periodic_watcher*);
@@ -106,6 +108,7 @@ static int ev_epoll_handler(void*);
 
 static int ev_epoll_io_start(struct io_watcher*);
 static int ev_epoll_io_stop(struct io_watcher*);
+static int ev_epoll_io_pause(struct io_watcher*);
 static int ev_epoll_io_handler(struct io_watcher*);
 
 static int ev_epoll_periodic_init(struct periodic_watcher*, int64_t, int64_t);
@@ -123,6 +126,7 @@ static int ev_kqueue_handler(struct kevent*);
 
 static int ev_kqueue_io_start(struct io_watcher*);
 static int ev_kqueue_io_stop(struct io_watcher*);
+static int ev_kqueue_io_pause(struct io_watcher*);
 static int ev_kqueue_io_handler(struct kevent*);
 
 static int ev_kqueue_periodic_init(struct periodic_watcher*, int64_t, int64_t);
@@ -223,6 +227,7 @@ setup_ops(void)
       loop_start = ev_io_uring_loop;
       io_start = ev_io_uring_io_start;
       io_stop = ev_io_uring_io_stop;
+      io_pause = ev_io_uring_io_pause;
       periodic_init = ev_io_uring_periodic_init;
       periodic_start = ev_io_uring_periodic_start;
       periodic_stop = ev_io_uring_periodic_stop;
@@ -243,6 +248,7 @@ setup_ops(void)
       loop_start = ev_epoll_loop;
       io_start = ev_epoll_io_start;
       io_stop = ev_epoll_io_stop;
+      io_pause = ev_epoll_io_pause;
       periodic_init = ev_epoll_periodic_init;
       periodic_start = ev_epoll_periodic_start;
       periodic_stop = ev_epoll_periodic_stop;
@@ -257,6 +263,7 @@ setup_ops(void)
       loop_start = ev_kqueue_loop;
       io_start = ev_kqueue_io_start;
       io_stop = ev_kqueue_io_stop;
+      io_pause = ev_kqueue_io_pause;
       periodic_init = ev_kqueue_periodic_init;
       periodic_start = ev_kqueue_periodic_start;
       periodic_stop = ev_kqueue_periodic_stop;
@@ -435,6 +442,11 @@ pgagroal_event_loop_is_running(void)
 {
    return atomic_load(&loop->running);
 }
+bool
+pgagroal_io_paused(struct io_watcher* watcher)
+{
+   return watcher->paused;
+}
 
 int
 pgagroal_event_accept_init(struct io_watcher* watcher, int listen_fd, io_cb cb)
@@ -548,6 +560,74 @@ pgagroal_io_stop(struct io_watcher* watcher)
    return PGAGROAL_EVENT_RC_OK;
 }
 
+int
+pgagroal_io_pause(struct io_watcher* watcher)
+{
+   int found_idx = -1;
+
+   if (event_loop_called_from_child("pgagroal_io_pause"))
+      return PGAGROAL_EVENT_RC_OK;
+
+   assert(loop != NULL && watcher != NULL);
+
+   if (watcher->paused)
+   {
+      pgagroal_log_warn("pgagroal_io_pause: watcher already paused (fd rcv=%d)",
+                        watcher->fds.worker.rcv_fd);
+      return PGAGROAL_EVENT_RC_ERROR;
+   }
+
+   for (int i = 0; i < loop->events_nr; i++)
+   {
+      if (watcher == (struct io_watcher*)loop->events[i])
+      {
+         found_idx = i;
+         break;
+      }
+   }
+
+   if (found_idx < 0)
+   {
+      pgagroal_log_warn("pgagroal_io_pause: watcher not found (fd rcv=%d)",
+                        watcher->fds.worker.rcv_fd);
+      return PGAGROAL_EVENT_RC_ERROR;
+   }
+
+   int rc = io_pause(watcher);
+   if (rc != PGAGROAL_EVENT_RC_OK)
+   {
+      pgagroal_log_error("pgagroal_io_pause: io_pause failed %d", rc);
+      return rc;
+   }
+
+   watcher->paused = true;
+
+   for (int j = found_idx; j < loop->events_nr - 1; j++)
+      loop->events[j] = loop->events[j + 1];
+   loop->events_nr--;
+   loop->events[loop->events_nr] = NULL;
+
+   return PGAGROAL_EVENT_RC_OK;
+}
+int
+pgagroal_io_resume(struct io_watcher* watcher)
+{
+   if (event_loop_called_from_child("pgagroal_io_resume"))
+      return PGAGROAL_EVENT_RC_OK;
+
+   assert(loop != NULL && watcher != NULL);
+
+   if (!pgagroal_io_paused(watcher))
+   {
+      pgagroal_log_warn("pgagroal_io_resume: watcher not paused (fd rcv=%d)",
+                        watcher->fds.worker.rcv_fd);
+      return PGAGROAL_EVENT_RC_ERROR;
+   }
+
+   watcher->paused = false;
+
+   return pgagroal_io_start(watcher);
+}
 int
 pgagroal_periodic_init(struct periodic_watcher* watcher, periodic_cb cb,
                        int64_t msec, int64_t repeat_ms)
@@ -942,6 +1022,24 @@ ev_io_uring_io_stop(struct io_watcher* target)
 }
 
 static int
+ev_io_uring_io_pause(struct io_watcher* watcher)
+{
+   struct io_uring_sqe* sqe = io_uring_get_sqe(&loop->ring_rcv);
+   if (!sqe)
+   {
+      pgagroal_log_error("io_uring: no SQE available for cancel (fd=%d)",
+                         watcher->fds.worker.rcv_fd);
+      return PGAGROAL_EVENT_RC_ERROR;
+   }
+
+   io_uring_prep_cancel(sqe, (void*)watcher, 0);
+   io_uring_sqe_set_data(sqe, NULL);
+   io_uring_submit(&loop->ring_rcv);
+
+   return PGAGROAL_EVENT_RC_OK;
+}
+
+static int
 ev_io_uring_periodic_init(struct periodic_watcher* watcher, int64_t msec, int64_t repeat_ms)
 {
    watcher->repeat_ms = repeat_ms;
@@ -1196,6 +1294,7 @@ ev_io_uring_handler(struct io_uring_cqe* cqe)
          break;
       case PGAGROAL_EVENT_TYPE_WORKER:
          io = (struct io_watcher*)watcher;
+
          msg = pgagroal_get_watcher_message(io);
          if (cqe->res <= 0)
          {
@@ -1219,8 +1318,8 @@ ev_io_uring_handler(struct io_uring_cqe* cqe)
             rc = PGAGROAL_EVENT_RC_OK;
             io->cb(io);
 
-            /* Only rearm if loop is still running and connection is good */
-            if (pgagroal_event_loop_is_running())
+            /* Only rearm if loop is still running, connection is good, and not paused */
+            if (pgagroal_event_loop_is_running() && !pgagroal_io_paused(io))
             {
                ev_io_uring_io_start(io);
             }
@@ -1561,6 +1660,13 @@ ev_epoll_io_stop(struct io_watcher* watcher)
 }
 
 static int
+ev_epoll_io_pause(struct io_watcher* watcher)
+{
+   /* epoll DEL — fd stays open */
+   return ev_epoll_io_stop(watcher);
+}
+
+static int
 ev_epoll_io_handler(struct io_watcher* watcher)
 {
    int client_fd = -1;
@@ -1855,6 +1961,13 @@ ev_kqueue_io_stop(struct io_watcher* watcher)
    }
 
    return PGAGROAL_EVENT_RC_OK;
+}
+
+static int
+ev_kqueue_io_pause(struct io_watcher* watcher)
+{
+   /* kqueue EV_DELETE — fd stays open */
+   return ev_kqueue_io_stop(watcher);
 }
 
 static int

--- a/src/libpgagroal/management.c
+++ b/src/libpgagroal/management.c
@@ -322,6 +322,76 @@ error:
 }
 
 int
+pgagroal_management_request_pause(SSL* ssl, int socket, int32_t mode, char* server, int64_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format)
+{
+   struct json* j = NULL;
+   struct json* request = NULL;
+
+   if (pgagroal_management_create_header(MANAGEMENT_PAUSE, compression, encryption, output_format, &j))
+   {
+      goto error;
+   }
+
+   if (pgagroal_management_create_request(j, &request))
+   {
+      goto error;
+   }
+
+   pgagroal_json_put(request, MANAGEMENT_ARGUMENT_MODE, (uintptr_t)mode, ValueInt32);
+   pgagroal_json_put(request, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)server, ValueString);
+   pgagroal_json_put(request, MANAGEMENT_ARGUMENT_TIMEOUT, (uintptr_t)timeout, ValueInt64);
+
+   if (pgagroal_management_write_json(ssl, socket, compression, encryption, j))
+   {
+      goto error;
+   }
+
+   pgagroal_json_destroy(j);
+
+   return 0;
+
+error:
+
+   pgagroal_json_destroy(j);
+
+   return 1;
+}
+
+int
+pgagroal_management_request_resume(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format)
+{
+   struct json* j = NULL;
+   struct json* request = NULL;
+
+   if (pgagroal_management_create_header(MANAGEMENT_RESUME, compression, encryption, output_format, &j))
+   {
+      goto error;
+   }
+
+   if (pgagroal_management_create_request(j, &request))
+   {
+      goto error;
+   }
+
+   pgagroal_json_put(request, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)server, ValueString);
+
+   if (pgagroal_management_write_json(ssl, socket, compression, encryption, j))
+   {
+      goto error;
+   }
+
+   pgagroal_json_destroy(j);
+
+   return 0;
+
+error:
+
+   pgagroal_json_destroy(j);
+
+   return 1;
+}
+
+int
 pgagroal_management_request_gracefully(SSL* ssl, int socket, int64_t timeout, uint8_t compression, uint8_t encryption, int32_t output_format)
 {
    struct json* j = NULL;
@@ -746,12 +816,37 @@ error:
    return 1;
 }
 
+void
+pgagroal_management_format_timestamp(time_t t, char* buffer, size_t size)
+{
+   struct tm* time_info;
+
+   if (buffer == NULL || size == 0)
+   {
+      return;
+   }
+
+   if (t == 0)
+   {
+      buffer[0] = '\0';
+      return;
+   }
+
+   time_info = localtime(&t);
+   if (time_info == NULL)
+   {
+      buffer[0] = '\0';
+      return;
+   }
+
+   strftime(buffer, size, "%Y%m%d%H%M%S", time_info);
+}
+
 int
 pgagroal_management_create_header(int32_t command, uint8_t compression, uint8_t encryption, int32_t output_format, struct json** json)
 {
    time_t t;
    char timestamp[128];
-   struct tm* time_info;
    struct json* j = NULL;
    struct json* header = NULL;
 
@@ -768,8 +863,7 @@ pgagroal_management_create_header(int32_t command, uint8_t compression, uint8_t 
    }
 
    time(&t);
-   time_info = localtime(&t);
-   strftime(&timestamp[0], sizeof(timestamp), "%Y%m%d%H%M%S", time_info);
+   pgagroal_management_format_timestamp(t, &timestamp[0], sizeof(timestamp));
 
    pgagroal_json_put(header, MANAGEMENT_ARGUMENT_COMMAND, (uintptr_t)command, ValueInt32);
    pgagroal_json_put(header, MANAGEMENT_ARGUMENT_CLIENT_VERSION, (uintptr_t)PGAGROAL_VERSION, ValueString);
@@ -1482,10 +1576,36 @@ read:
    if (ssl == NULL)
    {
       r = read(socket, buf + offset, needs);
+
+      if (r == 0)
+      {
+         errno = ECONNRESET;
+         goto error;
+      }
    }
    else
    {
       r = SSL_read(ssl, buf + offset, needs);
+
+      if (r <= 0)
+      {
+         int err = SSL_get_error(ssl, (int)r);
+
+         if (err == SSL_ERROR_ZERO_RETURN || r == 0)
+         {
+            errno = ECONNRESET;
+            goto error;
+         }
+
+         if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE)
+         {
+            errno = 0;
+            goto read;
+         }
+
+         ERR_clear_error();
+         goto error;
+      }
    }
 
    if (r == -1)
@@ -1498,7 +1618,7 @@ read:
 
       goto error;
    }
-   else if (r < needs)
+   else if (r < (ssize_t)needs)
    {
       SLEEP(10000000L)
 

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -34,6 +34,7 @@
 #include <management.h>
 #include <memory.h>
 #include <message.h>
+#include <pipeline.h>
 #include <pool.h>
 #include <prometheus.h>
 #include <security.h>
@@ -124,10 +125,15 @@ start:
          if (atomic_compare_exchange_strong(&config->states[i], &free, STATE_IN_USE))
          {
             bool can_reuse = false;
+            int conn_srv = config->connections[i].server;
 
+            if (config->all_paused || (conn_srv >= 0 && config->servers[conn_srv].paused))
+            {
+               can_reuse = false;
+            }
             // Check if same rule and username
-            if (best_rule == config->connections[i].limit_rule &&
-                !strcmp((const char*)(&config->connections[i].username), username))
+            else if (best_rule == config->connections[i].limit_rule &&
+                     !strcmp((const char*)(&config->connections[i].username), username))
             {
                real_database = resolve_database_name(database, best_rule);
                // Check exact database match
@@ -242,6 +248,25 @@ start:
                pgagroal_flush(FLUSH_GRACEFULLY, "*");
                exit(0);
             }
+
+            goto error;
+         }
+         while (config->keep_running &&
+                (config->all_paused || (server >= 0 && config->servers[server].paused)))
+         {
+            SLEEP(500000000L);
+         }
+
+         if (!config->keep_running)
+         {
+            if (best_rule >= 0)
+            {
+               /* The backend was reserved but never established; release it. */
+               atomic_fetch_sub(&config->limits[best_rule].backend_connections, 1);
+            }
+            config->connections[*slot].limit_rule = -1;
+            config->connections[*slot].pid = -1;
+            atomic_store(&config->states[*slot], STATE_NOTINIT);
 
             goto error;
          }
@@ -1255,6 +1280,337 @@ pgagroal_request_flush(SSL* ssl __attribute__((unused)), int client_fd, uint8_t 
    {
       pgagroal_flush(mode, "*");
    }
+
+   end_time = time(NULL);
+
+   pgagroal_management_response_ok(NULL, client_fd, start_time, end_time, compression, encryption, payload);
+
+   pgagroal_json_destroy(payload);
+
+   exit(0);
+}
+
+void
+pgagroal_resume(char* server)
+{
+   signed char srv = -1;
+   struct main_configuration* config;
+
+   pgagroal_start_logging();
+   pgagroal_memory_init();
+   config = (struct main_configuration*)shmem;
+
+   if (server != NULL && strcmp(server, "*") != 0)
+   {
+      for (int i = 0; i < config->number_of_servers; i++)
+      {
+         if (!strcmp(config->servers[i].name, server))
+         {
+            srv = i;
+            break;
+         }
+      }
+
+      if (srv == -1)
+      {
+         pgagroal_log_error("pgagroal_resume: Unknown server %s", server);
+         goto done;
+      }
+   }
+
+   /* Clear pause flags */
+   if (srv == -1)
+   {
+      config->all_paused = false;
+      for (int i = 0; i < config->number_of_servers; i++)
+      {
+         config->servers[i].paused = false;
+         config->servers[i].last_resumed = time(NULL);
+         pgagroal_prometheus_server_resume(i);
+      }
+   }
+   else
+   {
+      config->servers[srv].paused = false;
+      config->servers[srv].last_resumed = time(NULL);
+      pgagroal_prometheus_server_resume(srv);
+      config->all_paused = false;
+   }
+
+   pgagroal_log_debug("pgagroal_resume: server %s", server != NULL ? server : "all");
+
+   /* Wake paused workers */
+   for (int i = 0; i < config->max_connections; i++)
+   {
+      if (srv != -1 && config->connections[i].server != srv)
+         continue;
+
+      if (atomic_load(&config->states[i]) != STATE_IN_USE)
+         continue;
+
+      if (config->connections[i].pid <= 0)
+         continue;
+
+      /* worker is alive and owns the fd — just wake it */
+      pgagroal_log_debug("pgagroal_resume: slot %d waking worker (pid %d)",
+                         i, config->connections[i].pid);
+      kill(config->connections[i].pid, SIGUSR2);
+   }
+   pgagroal_prefill_if_can(true, true);
+
+done:
+   pgagroal_pool_status();
+   pgagroal_memory_destroy();
+   pgagroal_stop_logging();
+}
+
+void
+pgagroal_pause(int mode, char* server)
+{
+   signed char srv = -1;
+   time_t now;
+   struct main_configuration* config;
+
+   pgagroal_start_logging();
+   pgagroal_memory_init();
+   config = (struct main_configuration*)shmem;
+
+   if (server != NULL && strcmp(server, "*") != 0)
+   {
+      for (int i = 0; i < config->number_of_servers; i++)
+      {
+         if (!strcmp(config->servers[i].name, server))
+         {
+            srv = i;
+            break;
+         }
+      }
+
+      if (srv == -1)
+      {
+         pgagroal_log_error("pgagroal_pause: Unknown server %s", server);
+         goto done;
+      }
+   }
+
+   now = time(NULL);
+
+   if (srv == -1)
+   {
+      config->all_paused = true;
+      for (int i = 0; i < config->number_of_servers; i++)
+      {
+         if (strlen(config->servers[i].name) > 0)
+         {
+            if (!config->servers[i].paused)
+            {
+               pgagroal_prometheus_server_pause(i);
+            }
+            config->servers[i].paused = true;
+            config->servers[i].last_paused = now;
+         }
+      }
+   }
+   else
+   {
+      if (!config->servers[srv].paused)
+      {
+         pgagroal_prometheus_server_pause(srv);
+      }
+      config->servers[srv].paused = true;
+      config->servers[srv].last_paused = now;
+   }
+
+   pgagroal_log_debug("pgagroal_pause: server %s mode %d",
+                      server != NULL ? server : "all", mode);
+
+   for (int i = 0; i < config->max_connections; i++)
+   {
+      if (srv != -1 && config->connections[i].server != srv)
+      {
+         continue;
+      }
+
+      switch (atomic_load(&config->states[i]))
+      {
+         case STATE_NOTINIT:
+         case STATE_INIT:
+            break;
+
+         case STATE_FREE:
+            atomic_store(&config->states[i], STATE_GRACEFULLY);
+            if (pgagroal_socket_isvalid(config->connections[i].fd))
+            {
+               pgagroal_write_terminate(NULL, config->connections[i].fd);
+            }
+            pgagroal_kill_connection(i, NULL);
+            break;
+
+         case STATE_IN_USE:
+            if (mode == PAUSE_MODE_ALL)
+            {
+               int ret;
+               int socket = -1;
+               struct message* cancel_msg = NULL;
+               int conn_srv = config->connections[i].server;
+
+               pgagroal_create_cancel_request_message(config->connections[i].backend_pid,
+                                                      config->connections[i].backend_secret,
+                                                      &cancel_msg);
+
+               if (config->servers[conn_srv].host[0] == '/')
+               {
+                  char pgsql[MISC_LENGTH];
+                  memset(&pgsql, 0, sizeof(pgsql));
+                  snprintf(&pgsql[0], sizeof(pgsql), ".s.PGSQL.%d", config->servers[conn_srv].port);
+                  ret = pgagroal_connect_unix_socket(config->servers[conn_srv].host, &pgsql[0], &socket);
+               }
+               else
+               {
+                  ret = pgagroal_connect(config->servers[conn_srv].host, config->servers[conn_srv].port,
+                                         &socket, config->keep_alive, config->nodelay);
+               }
+
+               if (ret == 0)
+               {
+                  pgagroal_log_debug("Cancel request for %s/%s using slot %d (pid %d secret %d)",
+                                     config->connections[i].database, config->connections[i].username,
+                                     i, config->connections[i].backend_pid,
+                                     config->connections[i].backend_secret);
+                  pgagroal_write_message(NULL, socket, cancel_msg);
+               }
+               if (config->connections[i].pid > 0)
+               {
+                  pgagroal_log_info("Pause: signalling worker for slot %d (pid %d)",
+                                    i, config->connections[i].pid);
+                  kill(config->connections[i].pid, SIGUSR1);
+               }
+
+               pgagroal_disconnect(socket);
+               pgagroal_free_message(cancel_msg);
+               cancel_msg = NULL;
+            }
+            /* PAUSE_MODE_GRACEFULLY: do nothing, let transaction finish naturally */
+            break;
+
+         case STATE_GRACEFULLY:
+            break;
+
+         default:
+            break;
+      }
+   }
+
+done:
+   pgagroal_pool_status();
+   pgagroal_memory_destroy();
+   pgagroal_stop_logging();
+}
+void
+pgagroal_request_pause(SSL* ssl __attribute__((unused)), int client_fd, uint8_t compression, uint8_t encryption, struct json* payload)
+{
+   time_t start_time;
+   time_t end_time;
+   struct json* req = NULL;
+   int mode = PAUSE_MODE_GRACEFULLY;
+   char* server = NULL;
+
+   start_time = time(NULL);
+
+   req = (struct json*)pgagroal_json_get(payload, MANAGEMENT_CATEGORY_REQUEST);
+   if (pgagroal_json_contains_key(req, MANAGEMENT_ARGUMENT_MODE))
+   {
+      mode = (int)pgagroal_json_get(req, MANAGEMENT_ARGUMENT_MODE);
+   }
+   server = (char*)pgagroal_json_get(req, MANAGEMENT_ARGUMENT_SERVER);
+
+   pgagroal_pause(mode, server);
+
+   struct json* response = NULL;
+   struct json* servers = NULL;
+   struct main_configuration* config = (struct main_configuration*)shmem;
+
+   pgagroal_management_create_response(payload, -1, &response);
+   pgagroal_json_create(&servers);
+
+   for (int i = 0; i < config->number_of_servers; i++)
+   {
+      if (strlen(config->servers[i].name) > 0)
+      {
+         if (server != NULL && strcmp(server, "*") != 0 && strcmp(server, config->servers[i].name) != 0)
+         {
+            continue;
+         }
+
+         struct json* sobj = NULL;
+         char last_paused[MISC_LENGTH];
+         char last_resumed[MISC_LENGTH];
+
+         pgagroal_json_create(&sobj);
+         pgagroal_management_format_timestamp(config->servers[i].last_paused, last_paused, sizeof(last_paused));
+         pgagroal_management_format_timestamp(config->servers[i].last_resumed, last_resumed, sizeof(last_resumed));
+         pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_LAST_PAUSED, (uintptr_t)last_paused, ValueString);
+         pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_LAST_RESUMED, (uintptr_t)last_resumed, ValueString);
+
+         pgagroal_json_put(servers, config->servers[i].name, (uintptr_t)sobj, ValueJSON);
+      }
+   }
+   pgagroal_json_put(response, MANAGEMENT_ARGUMENT_SERVERS, (uintptr_t)servers, ValueJSON);
+
+   end_time = time(NULL);
+
+   pgagroal_management_response_ok(NULL, client_fd, start_time, end_time, compression, encryption, payload);
+
+   pgagroal_json_destroy(payload);
+
+   exit(0);
+}
+
+void
+pgagroal_request_resume(SSL* ssl __attribute__((unused)), int client_fd, uint8_t compression, uint8_t encryption, struct json* payload)
+{
+   time_t start_time;
+   time_t end_time;
+   struct json* req = NULL;
+   char* server = NULL;
+
+   start_time = time(NULL);
+
+   req = (struct json*)pgagroal_json_get(payload, MANAGEMENT_CATEGORY_REQUEST);
+   server = (char*)pgagroal_json_get(req, MANAGEMENT_ARGUMENT_SERVER);
+
+   pgagroal_resume(server);
+
+   struct json* response = NULL;
+   struct json* servers = NULL;
+   struct main_configuration* config = (struct main_configuration*)shmem;
+
+   pgagroal_management_create_response(payload, -1, &response);
+   pgagroal_json_create(&servers);
+
+   for (int i = 0; i < config->number_of_servers; i++)
+   {
+      if (strlen(config->servers[i].name) > 0)
+      {
+         if (server != NULL && strcmp(server, "*") != 0 && strcmp(server, config->servers[i].name) != 0)
+         {
+            continue;
+         }
+
+         struct json* sobj = NULL;
+         char last_paused[MISC_LENGTH];
+         char last_resumed[MISC_LENGTH];
+
+         pgagroal_json_create(&sobj);
+         pgagroal_management_format_timestamp(config->servers[i].last_paused, last_paused, sizeof(last_paused));
+         pgagroal_management_format_timestamp(config->servers[i].last_resumed, last_resumed, sizeof(last_resumed));
+         pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_LAST_PAUSED, (uintptr_t)last_paused, ValueString);
+         pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_LAST_RESUMED, (uintptr_t)last_resumed, ValueString);
+
+         pgagroal_json_put(servers, config->servers[i].name, (uintptr_t)sobj, ValueJSON);
+      }
+   }
+   pgagroal_json_put(response, MANAGEMENT_ARGUMENT_SERVERS, (uintptr_t)servers, ValueJSON);
 
    end_time = time(NULL);
 

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -34,6 +34,7 @@
 #include <management.h>
 #include <memory.h>
 #include <message.h>
+#include <pipeline.h>
 #include <pool.h>
 #include <prometheus.h>
 #include <security.h>
@@ -124,10 +125,15 @@ start:
          if (atomic_compare_exchange_strong(&config->states[i], &free, STATE_IN_USE))
          {
             bool can_reuse = false;
+            int conn_srv = config->connections[i].server;
 
+            if (config->all_paused || (conn_srv >= 0 && config->servers[conn_srv].paused))
+            {
+               can_reuse = false;
+            }
             // Check if same rule and username
-            if (best_rule == config->connections[i].limit_rule &&
-                !strcmp((const char*)(&config->connections[i].username), username))
+            else if (best_rule == config->connections[i].limit_rule &&
+                     !strcmp((const char*)(&config->connections[i].username), username))
             {
                real_database = resolve_database_name(database, best_rule);
                // Check exact database match
@@ -242,6 +248,25 @@ start:
                pgagroal_flush(FLUSH_GRACEFULLY, "*");
                exit(0);
             }
+
+            goto error;
+         }
+         while (config->keep_running &&
+                (config->all_paused || (server >= 0 && config->servers[server].paused)))
+         {
+            SLEEP(500000000L);
+         }
+
+         if (!config->keep_running)
+         {
+            if (best_rule >= 0)
+            {
+               /* The backend was reserved but never established; release it. */
+               atomic_fetch_sub(&config->limits[best_rule].backend_connections, 1);
+            }
+            config->connections[*slot].limit_rule = -1;
+            config->connections[*slot].pid = -1;
+            atomic_store(&config->states[*slot], STATE_NOTINIT);
 
             goto error;
          }
@@ -1238,6 +1263,337 @@ pgagroal_request_flush(SSL* ssl __attribute__((unused)), int client_fd, uint8_t 
    {
       pgagroal_flush(mode, "*");
    }
+
+   end_time = time(NULL);
+
+   pgagroal_management_response_ok(NULL, client_fd, start_time, end_time, compression, encryption, payload);
+
+   pgagroal_json_destroy(payload);
+
+   exit(0);
+}
+
+void
+pgagroal_resume(char* server)
+{
+   signed char srv = -1;
+   struct main_configuration* config;
+
+   pgagroal_start_logging();
+   pgagroal_memory_init();
+   config = (struct main_configuration*)shmem;
+
+   if (server != NULL && strcmp(server, "*") != 0)
+   {
+      for (int i = 0; i < config->number_of_servers; i++)
+      {
+         if (!strcmp(config->servers[i].name, server))
+         {
+            srv = i;
+            break;
+         }
+      }
+
+      if (srv == -1)
+      {
+         pgagroal_log_error("pgagroal_resume: Unknown server %s", server);
+         goto done;
+      }
+   }
+
+   /* Clear pause flags */
+   if (srv == -1)
+   {
+      config->all_paused = false;
+      for (int i = 0; i < config->number_of_servers; i++)
+      {
+         config->servers[i].paused = false;
+         config->servers[i].last_resumed = time(NULL);
+         pgagroal_prometheus_server_resume(i);
+      }
+   }
+   else
+   {
+      config->servers[srv].paused = false;
+      config->servers[srv].last_resumed = time(NULL);
+      pgagroal_prometheus_server_resume(srv);
+      config->all_paused = false;
+   }
+
+   pgagroal_log_debug("pgagroal_resume: server %s", server != NULL ? server : "all");
+
+   /* Wake paused workers */
+   for (int i = 0; i < config->max_connections; i++)
+   {
+      if (srv != -1 && config->connections[i].server != srv)
+         continue;
+
+      if (atomic_load(&config->states[i]) != STATE_IN_USE)
+         continue;
+
+      if (config->connections[i].pid <= 0)
+         continue;
+
+      /* worker is alive and owns the fd — just wake it */
+      pgagroal_log_debug("pgagroal_resume: slot %d waking worker (pid %d)",
+                         i, config->connections[i].pid);
+      kill(config->connections[i].pid, SIGUSR2);
+   }
+   pgagroal_prefill_if_can(true, true);
+
+done:
+   pgagroal_pool_status();
+   pgagroal_memory_destroy();
+   pgagroal_stop_logging();
+}
+
+void
+pgagroal_pause(int mode, char* server)
+{
+   signed char srv = -1;
+   time_t now;
+   struct main_configuration* config;
+
+   pgagroal_start_logging();
+   pgagroal_memory_init();
+   config = (struct main_configuration*)shmem;
+
+   if (server != NULL && strcmp(server, "*") != 0)
+   {
+      for (int i = 0; i < config->number_of_servers; i++)
+      {
+         if (!strcmp(config->servers[i].name, server))
+         {
+            srv = i;
+            break;
+         }
+      }
+
+      if (srv == -1)
+      {
+         pgagroal_log_error("pgagroal_pause: Unknown server %s", server);
+         goto done;
+      }
+   }
+
+   now = time(NULL);
+
+   if (srv == -1)
+   {
+      config->all_paused = true;
+      for (int i = 0; i < config->number_of_servers; i++)
+      {
+         if (strlen(config->servers[i].name) > 0)
+         {
+            if (!config->servers[i].paused)
+            {
+               pgagroal_prometheus_server_pause(i);
+            }
+            config->servers[i].paused = true;
+            config->servers[i].last_paused = now;
+         }
+      }
+   }
+   else
+   {
+      if (!config->servers[srv].paused)
+      {
+         pgagroal_prometheus_server_pause(srv);
+      }
+      config->servers[srv].paused = true;
+      config->servers[srv].last_paused = now;
+   }
+
+   pgagroal_log_debug("pgagroal_pause: server %s mode %d",
+                      server != NULL ? server : "all", mode);
+
+   for (int i = 0; i < config->max_connections; i++)
+   {
+      if (srv != -1 && config->connections[i].server != srv)
+      {
+         continue;
+      }
+
+      switch (atomic_load(&config->states[i]))
+      {
+         case STATE_NOTINIT:
+         case STATE_INIT:
+            break;
+
+         case STATE_FREE:
+            atomic_store(&config->states[i], STATE_GRACEFULLY);
+            if (pgagroal_socket_isvalid(config->connections[i].fd))
+            {
+               pgagroal_write_terminate(NULL, config->connections[i].fd);
+            }
+            pgagroal_kill_connection(i, NULL);
+            break;
+
+         case STATE_IN_USE:
+            if (mode == PAUSE_MODE_ALL)
+            {
+               int ret;
+               int socket = -1;
+               struct message* cancel_msg = NULL;
+               int conn_srv = config->connections[i].server;
+
+               pgagroal_create_cancel_request_message(config->connections[i].backend_pid,
+                                                      config->connections[i].backend_secret,
+                                                      &cancel_msg);
+
+               if (config->servers[conn_srv].host[0] == '/')
+               {
+                  char pgsql[MISC_LENGTH];
+                  memset(&pgsql, 0, sizeof(pgsql));
+                  snprintf(&pgsql[0], sizeof(pgsql), ".s.PGSQL.%d", config->servers[conn_srv].port);
+                  ret = pgagroal_connect_unix_socket(config->servers[conn_srv].host, &pgsql[0], &socket);
+               }
+               else
+               {
+                  ret = pgagroal_connect(config->servers[conn_srv].host, config->servers[conn_srv].port,
+                                         &socket, config->keep_alive, config->nodelay);
+               }
+
+               if (ret == 0)
+               {
+                  pgagroal_log_debug("Cancel request for %s/%s using slot %d (pid %d secret %d)",
+                                     config->connections[i].database, config->connections[i].username,
+                                     i, config->connections[i].backend_pid,
+                                     config->connections[i].backend_secret);
+                  pgagroal_write_message(NULL, socket, cancel_msg);
+               }
+               if (config->connections[i].pid > 0)
+               {
+                  pgagroal_log_info("Pause: signalling worker for slot %d (pid %d)",
+                                    i, config->connections[i].pid);
+                  kill(config->connections[i].pid, SIGUSR1);
+               }
+
+               pgagroal_disconnect(socket);
+               pgagroal_free_message(cancel_msg);
+               cancel_msg = NULL;
+            }
+            /* PAUSE_MODE_GRACEFULLY: do nothing, let transaction finish naturally */
+            break;
+
+         case STATE_GRACEFULLY:
+            break;
+
+         default:
+            break;
+      }
+   }
+
+done:
+   pgagroal_pool_status();
+   pgagroal_memory_destroy();
+   pgagroal_stop_logging();
+}
+void
+pgagroal_request_pause(SSL* ssl __attribute__((unused)), int client_fd, uint8_t compression, uint8_t encryption, struct json* payload)
+{
+   time_t start_time;
+   time_t end_time;
+   struct json* req = NULL;
+   int mode = PAUSE_MODE_GRACEFULLY;
+   char* server = NULL;
+
+   start_time = time(NULL);
+
+   req = (struct json*)pgagroal_json_get(payload, MANAGEMENT_CATEGORY_REQUEST);
+   if (pgagroal_json_contains_key(req, MANAGEMENT_ARGUMENT_MODE))
+   {
+      mode = (int)pgagroal_json_get(req, MANAGEMENT_ARGUMENT_MODE);
+   }
+   server = (char*)pgagroal_json_get(req, MANAGEMENT_ARGUMENT_SERVER);
+
+   pgagroal_pause(mode, server);
+
+   struct json* response = NULL;
+   struct json* servers = NULL;
+   struct main_configuration* config = (struct main_configuration*)shmem;
+
+   pgagroal_management_create_response(payload, -1, &response);
+   pgagroal_json_create(&servers);
+
+   for (int i = 0; i < config->number_of_servers; i++)
+   {
+      if (strlen(config->servers[i].name) > 0)
+      {
+         if (server != NULL && strcmp(server, "*") != 0 && strcmp(server, config->servers[i].name) != 0)
+         {
+            continue;
+         }
+
+         struct json* sobj = NULL;
+         char last_paused[MISC_LENGTH];
+         char last_resumed[MISC_LENGTH];
+
+         pgagroal_json_create(&sobj);
+         pgagroal_management_format_timestamp(config->servers[i].last_paused, last_paused, sizeof(last_paused));
+         pgagroal_management_format_timestamp(config->servers[i].last_resumed, last_resumed, sizeof(last_resumed));
+         pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_LAST_PAUSED, (uintptr_t)last_paused, ValueString);
+         pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_LAST_RESUMED, (uintptr_t)last_resumed, ValueString);
+
+         pgagroal_json_put(servers, config->servers[i].name, (uintptr_t)sobj, ValueJSON);
+      }
+   }
+   pgagroal_json_put(response, MANAGEMENT_ARGUMENT_SERVERS, (uintptr_t)servers, ValueJSON);
+
+   end_time = time(NULL);
+
+   pgagroal_management_response_ok(NULL, client_fd, start_time, end_time, compression, encryption, payload);
+
+   pgagroal_json_destroy(payload);
+
+   exit(0);
+}
+
+void
+pgagroal_request_resume(SSL* ssl __attribute__((unused)), int client_fd, uint8_t compression, uint8_t encryption, struct json* payload)
+{
+   time_t start_time;
+   time_t end_time;
+   struct json* req = NULL;
+   char* server = NULL;
+
+   start_time = time(NULL);
+
+   req = (struct json*)pgagroal_json_get(payload, MANAGEMENT_CATEGORY_REQUEST);
+   server = (char*)pgagroal_json_get(req, MANAGEMENT_ARGUMENT_SERVER);
+
+   pgagroal_resume(server);
+
+   struct json* response = NULL;
+   struct json* servers = NULL;
+   struct main_configuration* config = (struct main_configuration*)shmem;
+
+   pgagroal_management_create_response(payload, -1, &response);
+   pgagroal_json_create(&servers);
+
+   for (int i = 0; i < config->number_of_servers; i++)
+   {
+      if (strlen(config->servers[i].name) > 0)
+      {
+         if (server != NULL && strcmp(server, "*") != 0 && strcmp(server, config->servers[i].name) != 0)
+         {
+            continue;
+         }
+
+         struct json* sobj = NULL;
+         char last_paused[MISC_LENGTH];
+         char last_resumed[MISC_LENGTH];
+
+         pgagroal_json_create(&sobj);
+         pgagroal_management_format_timestamp(config->servers[i].last_paused, last_paused, sizeof(last_paused));
+         pgagroal_management_format_timestamp(config->servers[i].last_resumed, last_resumed, sizeof(last_resumed));
+         pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_LAST_PAUSED, (uintptr_t)last_paused, ValueString);
+         pgagroal_json_put(sobj, MANAGEMENT_ARGUMENT_LAST_RESUMED, (uintptr_t)last_resumed, ValueString);
+
+         pgagroal_json_put(servers, config->servers[i].name, (uintptr_t)sobj, ValueJSON);
+      }
+   }
+   pgagroal_json_put(response, MANAGEMENT_ARGUMENT_SERVERS, (uintptr_t)servers, ValueJSON);
 
    end_time = time(NULL);
 

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -406,6 +406,8 @@ pgagroal_init_prometheus(size_t* p_size, void** p_shmem)
    for (int i = 0; i < NUMBER_OF_SERVERS; i++)
    {
       atomic_init(&prometheus->server_error[i], 0);
+      atomic_init(&prometheus->server_pause_total[i], 0);
+      atomic_init(&prometheus->server_resume_total[i], 0);
    }
    atomic_init(&prometheus->failed_servers, 0);
 
@@ -1090,6 +1092,8 @@ pgagroal_prometheus_clear(void)
    for (int i = 0; i < NUMBER_OF_SERVERS; i++)
    {
       atomic_store(&prometheus->server_error[i], 0);
+      atomic_store(&prometheus->server_pause_total[i], 0);
+      atomic_store(&prometheus->server_resume_total[i], 0);
    }
 
    for (int i = 0; i < config->max_connections; i++)
@@ -1125,6 +1129,46 @@ pgagroal_prometheus_server_error(int server)
    prometheus = (struct main_prometheus*)prometheus_shmem;
 
    atomic_fetch_add(&prometheus->server_error[server], 1);
+}
+
+void
+pgagroal_prometheus_server_pause(int server)
+{
+   struct main_prometheus* prometheus;
+
+   if (!is_prometheus_enabled())
+   {
+      return;
+   }
+
+   if (server < 0 || server >= NUMBER_OF_SERVERS)
+   {
+      return;
+   }
+
+   prometheus = (struct main_prometheus*)prometheus_shmem;
+
+   atomic_fetch_add(&prometheus->server_pause_total[server], 1);
+}
+
+void
+pgagroal_prometheus_server_resume(int server)
+{
+   struct main_prometheus* prometheus;
+
+   if (!is_prometheus_enabled())
+   {
+      return;
+   }
+
+   if (server < 0 || server >= NUMBER_OF_SERVERS)
+   {
+      return;
+   }
+
+   prometheus = (struct main_prometheus*)prometheus_shmem;
+
+   atomic_fetch_add(&prometheus->server_resume_total[server], 1);
 }
 
 void
@@ -1482,6 +1526,90 @@ home_page(SSL* client_ssl, int client_fd)
    data = pgagroal_append(data, "            <li>failed</li>\n");
    data = pgagroal_append(data, "          </ul>\n");
    data = pgagroal_append(data, "        </td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "    </tbody>\n");
+   data = pgagroal_append(data, "  </table>\n");
+   data = pgagroal_append(data, "  <h2>pgagroal_server_pause_total</h2>\n");
+   data = pgagroal_append(data, "  <p>\n");
+   data = pgagroal_append(data, "   Successful pause operations per server\n");
+   data = pgagroal_append(data, "  </p>\n");
+   data = pgagroal_append(data, "  <table>\n");
+   data = pgagroal_append(data, "    <tbody>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>name</td>\n");
+   data = pgagroal_append(data, "        <td>The name of the server</td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>state</td>\n");
+   data = pgagroal_append(data, "        <td>The server state\n");
+   data = pgagroal_append(data, "          <ul>\n");
+   data = pgagroal_append(data, "            <li>not_init</li>\n");
+   data = pgagroal_append(data, "            <li>primary</li>\n");
+   data = pgagroal_append(data, "            <li>replica</li>\n");
+   data = pgagroal_append(data, "            <li>failover</li>\n");
+   data = pgagroal_append(data, "            <li>failed</li>\n");
+   data = pgagroal_append(data, "          </ul>\n");
+   data = pgagroal_append(data, "        </td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "    </tbody>\n");
+   data = pgagroal_append(data, "  </table>\n");
+   data = pgagroal_append(data, "  <h2>pgagroal_server_resume_total</h2>\n");
+   data = pgagroal_append(data, "  <p>\n");
+   data = pgagroal_append(data, "   Successful resume operations per server\n");
+   data = pgagroal_append(data, "  </p>\n");
+   data = pgagroal_append(data, "  <table>\n");
+   data = pgagroal_append(data, "    <tbody>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>name</td>\n");
+   data = pgagroal_append(data, "        <td>The name of the server</td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>state</td>\n");
+   data = pgagroal_append(data, "        <td>The server state\n");
+   data = pgagroal_append(data, "          <ul>\n");
+   data = pgagroal_append(data, "            <li>not_init</li>\n");
+   data = pgagroal_append(data, "            <li>primary</li>\n");
+   data = pgagroal_append(data, "            <li>replica</li>\n");
+   data = pgagroal_append(data, "            <li>failover</li>\n");
+   data = pgagroal_append(data, "            <li>failed</li>\n");
+   data = pgagroal_append(data, "          </ul>\n");
+   data = pgagroal_append(data, "        </td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "    </tbody>\n");
+   data = pgagroal_append(data, "  </table>\n");
+   data = pgagroal_append(data, "  <h2>pgagroal_server_pause_state</h2>\n");
+   data = pgagroal_append(data, "  <p>\n");
+   data = pgagroal_append(data, "   The pause state of the server (0 = running, 1 = paused)\n");
+   data = pgagroal_append(data, "  </p>\n");
+   data = pgagroal_append(data, "  <table>\n");
+   data = pgagroal_append(data, "    <tbody>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>name</td>\n");
+   data = pgagroal_append(data, "        <td>The name of the server</td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "    </tbody>\n");
+   data = pgagroal_append(data, "  </table>\n");
+   data = pgagroal_append(data, "  <h2>pgagroal_pause_pending_active_connections</h2>\n");
+   data = pgagroal_append(data, "  <p>\n");
+   data = pgagroal_append(data, "   The number of slots still in use on a paused server (0 when fully drained)\n");
+   data = pgagroal_append(data, "  </p>\n");
+   data = pgagroal_append(data, "  <table>\n");
+   data = pgagroal_append(data, "    <tbody>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>name</td>\n");
+   data = pgagroal_append(data, "        <td>The name of the server</td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "    </tbody>\n");
+   data = pgagroal_append(data, "  </table>\n");
+   data = pgagroal_append(data, "  <h2>pgagroal_server_last_paused_timestamp</h2>\n");
+   data = pgagroal_append(data, "  <p>\n");
+   data = pgagroal_append(data, "   The Unix time when the server was paused (0 if running). Duration is derived as time() minus this value\n");
+   data = pgagroal_append(data, "  </p>\n");
+   data = pgagroal_append(data, "  <table>\n");
+   data = pgagroal_append(data, "    <tbody>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>name</td>\n");
+   data = pgagroal_append(data, "        <td>The name of the server</td>\n");
    data = pgagroal_append(data, "      </tr>\n");
    data = pgagroal_append(data, "    </tbody>\n");
    data = pgagroal_append(data, "  </table>\n");
@@ -2379,6 +2507,102 @@ general_information(prometheus_metrics_container_t* container)
       data = NULL;
    }
 
+   data = pgagroal_append(data, "#HELP pgagroal_server_pause_total The number of successful pause operations per server\n");
+   data = pgagroal_append(data, "#TYPE pgagroal_server_pause_total counter\n");
+   FOREACH_VALID_SERVER
+   {
+      int state = atomic_load(&config->servers[i].state);
+
+      data = pgagroal_append(data, "pgagroal_server_pause_total{");
+
+      data = pgagroal_append(data, "name=\"");
+      data = pgagroal_append(data, config->servers[i].name);
+      data = pgagroal_append(data, "\",");
+
+      data = pgagroal_append(data, "state=\"");
+
+      switch (state)
+      {
+         case SERVER_NOTINIT:
+         case SERVER_NOTINIT_PRIMARY:
+            data = pgagroal_append(data, "not_init");
+            break;
+         case SERVER_PRIMARY:
+            data = pgagroal_append(data, "primary");
+            break;
+         case SERVER_REPLICA:
+            data = pgagroal_append(data, "replica");
+            break;
+         case SERVER_FAILOVER:
+            data = pgagroal_append(data, "failover");
+            break;
+         case SERVER_FAILED:
+            data = pgagroal_append(data, "failed");
+            break;
+         default:
+            break;
+      }
+
+      data = pgagroal_append(data, "\"} ");
+
+      data = pgagroal_append_ulong(data, atomic_load(&prometheus->server_pause_total[i]));
+      data = pgagroal_append(data, "\n");
+   }
+   if (data != NULL)
+   {
+      add_metric_to_art(container->general_metrics, "pgagroal_server_pause_total", data, NULL, NULL, 0);
+      free(data);
+      data = NULL;
+   }
+
+   data = pgagroal_append(data, "#HELP pgagroal_server_resume_total The number of successful resume operations per server\n");
+   data = pgagroal_append(data, "#TYPE pgagroal_server_resume_total counter\n");
+   FOREACH_VALID_SERVER
+   {
+      int state = atomic_load(&config->servers[i].state);
+
+      data = pgagroal_append(data, "pgagroal_server_resume_total{");
+
+      data = pgagroal_append(data, "name=\"");
+      data = pgagroal_append(data, config->servers[i].name);
+      data = pgagroal_append(data, "\",");
+
+      data = pgagroal_append(data, "state=\"");
+
+      switch (state)
+      {
+         case SERVER_NOTINIT:
+         case SERVER_NOTINIT_PRIMARY:
+            data = pgagroal_append(data, "not_init");
+            break;
+         case SERVER_PRIMARY:
+            data = pgagroal_append(data, "primary");
+            break;
+         case SERVER_REPLICA:
+            data = pgagroal_append(data, "replica");
+            break;
+         case SERVER_FAILOVER:
+            data = pgagroal_append(data, "failover");
+            break;
+         case SERVER_FAILED:
+            data = pgagroal_append(data, "failed");
+            break;
+         default:
+            break;
+      }
+
+      data = pgagroal_append(data, "\"} ");
+
+      data = pgagroal_append_ulong(data, atomic_load(&prometheus->server_resume_total[i]));
+      data = pgagroal_append(data, "\n");
+   }
+   if (data != NULL)
+   {
+      add_metric_to_art(container->general_metrics, "pgagroal_server_resume_total", data, NULL, NULL, 0);
+      free(data);
+      data = NULL;
+   }
+
    data = pgagroal_append(data, "#HELP pgagroal_logging_info The number of INFO logging statements\n");
    data = pgagroal_append(data, "#TYPE pgagroal_logging_info gauge\n");
    data = pgagroal_append(data, "pgagroal_logging_info ");
@@ -2483,6 +2707,75 @@ general_information(prometheus_metrics_container_t* container)
       data = pgagroal_append(data, "\n");
    }
    data = pgagroal_append(data, "\n");
+
+   /* Pause metrics are derived from authoritative state:
+    *   - paused  : explicit bool on struct server
+    *   - pending : count of STATE_IN_USE slots on a paused server
+    * A server is fully drained when paused with pending == 0. */
+   {
+      int pending_per_server[NUMBER_OF_SERVERS];
+
+      for (int s = 0; s < config->number_of_servers; s++)
+      {
+         pending_per_server[s] = 0;
+      }
+      for (int i = 0; i < config->max_connections; i++)
+      {
+         int srv = config->connections[i].server;
+         if (srv >= 0 && srv < config->number_of_servers &&
+             config->servers[srv].paused &&
+             atomic_load(&config->states[i]) == STATE_IN_USE)
+         {
+            pending_per_server[srv]++;
+         }
+      }
+
+      data = pgagroal_append(data, "#HELP pgagroal_server_pause_state The pause state of the server (0 = running, 1 = paused)\n");
+      data = pgagroal_append(data, "#TYPE pgagroal_server_pause_state gauge\n");
+      FOREACH_VALID_SERVER
+      {
+         int v = config->servers[i].paused ? 1 : 0;
+         data = pgagroal_append(data, "pgagroal_server_pause_state{name=\"");
+         data = pgagroal_append(data, config->servers[i].name);
+         data = pgagroal_append(data, "\"} ");
+         data = pgagroal_append_int(data, v);
+         data = pgagroal_append(data, "\n");
+      }
+      add_metric_to_art(container->general_metrics, "pgagroal_server_pause_state", data, NULL, NULL, 0);
+      free(data);
+      data = NULL;
+
+      data = pgagroal_append(data, "#HELP pgagroal_pause_pending_active_connections Slots still STATE_IN_USE on a paused server\n");
+      data = pgagroal_append(data, "#TYPE pgagroal_pause_pending_active_connections gauge\n");
+      FOREACH_VALID_SERVER
+      {
+         data = pgagroal_append(data, "pgagroal_pause_pending_active_connections{name=\"");
+         data = pgagroal_append(data, config->servers[i].name);
+         data = pgagroal_append(data, "\"} ");
+         data = pgagroal_append_int(data, pending_per_server[i]);
+         data = pgagroal_append(data, "\n");
+      }
+      add_metric_to_art(container->general_metrics, "pgagroal_pause_pending_active_connections", data, NULL, NULL, 0);
+      free(data);
+      data = NULL;
+
+      /* Unix timestamp of the current pause (0 when the server is running).
+       * Duration is derived in PromQL: time() - pgagroal_server_last_paused_timestamp. */
+      data = pgagroal_append(data, "#HELP pgagroal_server_last_paused_timestamp Unix time when the server was paused (0 if running)\n");
+      data = pgagroal_append(data, "#TYPE pgagroal_server_last_paused_timestamp gauge\n");
+      FOREACH_VALID_SERVER
+      {
+         uint64_t ts = config->servers[i].paused ? (uint64_t)config->servers[i].last_paused : 0;
+         data = pgagroal_append(data, "pgagroal_server_last_paused_timestamp{name=\"");
+         data = pgagroal_append(data, config->servers[i].name);
+         data = pgagroal_append(data, "\"} ");
+         data = pgagroal_append_ulong(data, ts);
+         data = pgagroal_append(data, "\n");
+      }
+      add_metric_to_art(container->general_metrics, "pgagroal_server_last_paused_timestamp", data, NULL, NULL, 0);
+      free(data);
+      data = NULL;
+   }
 
    data = pgagroal_append(data, "#HELP pgagroal_wait_time The waiting time of clients\n");
    data = pgagroal_append(data, "#TYPE pgagroal_wait_time gauge\n");

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -406,6 +406,8 @@ pgagroal_init_prometheus(size_t* p_size, void** p_shmem)
    for (int i = 0; i < NUMBER_OF_SERVERS; i++)
    {
       atomic_init(&prometheus->server_error[i], 0);
+      atomic_init(&prometheus->server_pause_total[i], 0);
+      atomic_init(&prometheus->server_resume_total[i], 0);
    }
    atomic_init(&prometheus->failed_servers, 0);
 
@@ -1090,6 +1092,8 @@ pgagroal_prometheus_clear(void)
    for (int i = 0; i < NUMBER_OF_SERVERS; i++)
    {
       atomic_store(&prometheus->server_error[i], 0);
+      atomic_store(&prometheus->server_pause_total[i], 0);
+      atomic_store(&prometheus->server_resume_total[i], 0);
    }
 
    for (int i = 0; i < config->max_connections; i++)
@@ -1125,6 +1129,46 @@ pgagroal_prometheus_server_error(int server)
    prometheus = (struct main_prometheus*)prometheus_shmem;
 
    atomic_fetch_add(&prometheus->server_error[server], 1);
+}
+
+void
+pgagroal_prometheus_server_pause(int server)
+{
+   struct main_prometheus* prometheus;
+
+   if (!is_prometheus_enabled())
+   {
+      return;
+   }
+
+   if (server < 0 || server >= NUMBER_OF_SERVERS)
+   {
+      return;
+   }
+
+   prometheus = (struct main_prometheus*)prometheus_shmem;
+
+   atomic_fetch_add(&prometheus->server_pause_total[server], 1);
+}
+
+void
+pgagroal_prometheus_server_resume(int server)
+{
+   struct main_prometheus* prometheus;
+
+   if (!is_prometheus_enabled())
+   {
+      return;
+   }
+
+   if (server < 0 || server >= NUMBER_OF_SERVERS)
+   {
+      return;
+   }
+
+   prometheus = (struct main_prometheus*)prometheus_shmem;
+
+   atomic_fetch_add(&prometheus->server_resume_total[server], 1);
 }
 
 void
@@ -1506,6 +1550,90 @@ home_page(SSL* client_ssl, int client_fd)
    data = pgagroal_append(data, "  <h2>pgagroal_server_streaming</h2>\n");
    data = pgagroal_append(data, "  <p>\n");
    data = pgagroal_append(data, "   Whether a standby is actively streaming from its primary (-1=primary, 0=no, 1=yes)\n");
+   data = pgagroal_append(data, "  </p>\n");
+   data = pgagroal_append(data, "  <table>\n");
+   data = pgagroal_append(data, "    <tbody>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>name</td>\n");
+   data = pgagroal_append(data, "        <td>The name of the server</td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "    </tbody>\n");
+   data = pgagroal_append(data, "  </table>\n");
+   data = pgagroal_append(data, "  <h2>pgagroal_server_pause_total</h2>\n");
+   data = pgagroal_append(data, "  <p>\n");
+   data = pgagroal_append(data, "   Successful pause operations per server\n");
+   data = pgagroal_append(data, "  </p>\n");
+   data = pgagroal_append(data, "  <table>\n");
+   data = pgagroal_append(data, "    <tbody>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>name</td>\n");
+   data = pgagroal_append(data, "        <td>The name of the server</td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>state</td>\n");
+   data = pgagroal_append(data, "        <td>The server state\n");
+   data = pgagroal_append(data, "          <ul>\n");
+   data = pgagroal_append(data, "            <li>not_init</li>\n");
+   data = pgagroal_append(data, "            <li>primary</li>\n");
+   data = pgagroal_append(data, "            <li>replica</li>\n");
+   data = pgagroal_append(data, "            <li>failover</li>\n");
+   data = pgagroal_append(data, "            <li>failed</li>\n");
+   data = pgagroal_append(data, "          </ul>\n");
+   data = pgagroal_append(data, "        </td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "    </tbody>\n");
+   data = pgagroal_append(data, "  </table>\n");
+   data = pgagroal_append(data, "  <h2>pgagroal_server_resume_total</h2>\n");
+   data = pgagroal_append(data, "  <p>\n");
+   data = pgagroal_append(data, "   Successful resume operations per server\n");
+   data = pgagroal_append(data, "  </p>\n");
+   data = pgagroal_append(data, "  <table>\n");
+   data = pgagroal_append(data, "    <tbody>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>name</td>\n");
+   data = pgagroal_append(data, "        <td>The name of the server</td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>state</td>\n");
+   data = pgagroal_append(data, "        <td>The server state\n");
+   data = pgagroal_append(data, "          <ul>\n");
+   data = pgagroal_append(data, "            <li>not_init</li>\n");
+   data = pgagroal_append(data, "            <li>primary</li>\n");
+   data = pgagroal_append(data, "            <li>replica</li>\n");
+   data = pgagroal_append(data, "            <li>failover</li>\n");
+   data = pgagroal_append(data, "            <li>failed</li>\n");
+   data = pgagroal_append(data, "          </ul>\n");
+   data = pgagroal_append(data, "        </td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "    </tbody>\n");
+   data = pgagroal_append(data, "  </table>\n");
+   data = pgagroal_append(data, "  <h2>pgagroal_server_pause_state</h2>\n");
+   data = pgagroal_append(data, "  <p>\n");
+   data = pgagroal_append(data, "   The pause state of the server (0 = running, 1 = paused)\n");
+   data = pgagroal_append(data, "  </p>\n");
+   data = pgagroal_append(data, "  <table>\n");
+   data = pgagroal_append(data, "    <tbody>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>name</td>\n");
+   data = pgagroal_append(data, "        <td>The name of the server</td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "    </tbody>\n");
+   data = pgagroal_append(data, "  </table>\n");
+   data = pgagroal_append(data, "  <h2>pgagroal_pause_pending_active_connections</h2>\n");
+   data = pgagroal_append(data, "  <p>\n");
+   data = pgagroal_append(data, "   The number of slots still in use on a paused server (0 when fully drained)\n");
+   data = pgagroal_append(data, "  </p>\n");
+   data = pgagroal_append(data, "  <table>\n");
+   data = pgagroal_append(data, "    <tbody>\n");
+   data = pgagroal_append(data, "      <tr>\n");
+   data = pgagroal_append(data, "        <td>name</td>\n");
+   data = pgagroal_append(data, "        <td>The name of the server</td>\n");
+   data = pgagroal_append(data, "      </tr>\n");
+   data = pgagroal_append(data, "    </tbody>\n");
+   data = pgagroal_append(data, "  </table>\n");
+   data = pgagroal_append(data, "  <h2>pgagroal_server_last_paused_timestamp</h2>\n");
+   data = pgagroal_append(data, "  <p>\n");
+   data = pgagroal_append(data, "   The Unix time when the server was paused (0 if running). Duration is derived as time() minus this value\n");
    data = pgagroal_append(data, "  </p>\n");
    data = pgagroal_append(data, "  <table>\n");
    data = pgagroal_append(data, "    <tbody>\n");
@@ -2418,6 +2546,102 @@ general_information(prometheus_metrics_container_t* container)
       data = NULL;
    }
 
+   data = pgagroal_append(data, "#HELP pgagroal_server_pause_total The number of successful pause operations per server\n");
+   data = pgagroal_append(data, "#TYPE pgagroal_server_pause_total counter\n");
+   FOREACH_VALID_SERVER
+   {
+      int state = atomic_load(&config->servers[i].state);
+
+      data = pgagroal_append(data, "pgagroal_server_pause_total{");
+
+      data = pgagroal_append(data, "name=\"");
+      data = pgagroal_append(data, config->servers[i].name);
+      data = pgagroal_append(data, "\",");
+
+      data = pgagroal_append(data, "state=\"");
+
+      switch (state)
+      {
+         case SERVER_NOTINIT:
+         case SERVER_NOTINIT_PRIMARY:
+            data = pgagroal_append(data, "not_init");
+            break;
+         case SERVER_PRIMARY:
+            data = pgagroal_append(data, "primary");
+            break;
+         case SERVER_REPLICA:
+            data = pgagroal_append(data, "replica");
+            break;
+         case SERVER_FAILOVER:
+            data = pgagroal_append(data, "failover");
+            break;
+         case SERVER_FAILED:
+            data = pgagroal_append(data, "failed");
+            break;
+         default:
+            break;
+      }
+
+      data = pgagroal_append(data, "\"} ");
+
+      data = pgagroal_append_ulong(data, atomic_load(&prometheus->server_pause_total[i]));
+      data = pgagroal_append(data, "\n");
+   }
+   if (data != NULL)
+   {
+      add_metric_to_art(container->general_metrics, "pgagroal_server_pause_total", data, NULL, NULL, 0);
+      free(data);
+      data = NULL;
+   }
+
+   data = pgagroal_append(data, "#HELP pgagroal_server_resume_total The number of successful resume operations per server\n");
+   data = pgagroal_append(data, "#TYPE pgagroal_server_resume_total counter\n");
+   FOREACH_VALID_SERVER
+   {
+      int state = atomic_load(&config->servers[i].state);
+
+      data = pgagroal_append(data, "pgagroal_server_resume_total{");
+
+      data = pgagroal_append(data, "name=\"");
+      data = pgagroal_append(data, config->servers[i].name);
+      data = pgagroal_append(data, "\",");
+
+      data = pgagroal_append(data, "state=\"");
+
+      switch (state)
+      {
+         case SERVER_NOTINIT:
+         case SERVER_NOTINIT_PRIMARY:
+            data = pgagroal_append(data, "not_init");
+            break;
+         case SERVER_PRIMARY:
+            data = pgagroal_append(data, "primary");
+            break;
+         case SERVER_REPLICA:
+            data = pgagroal_append(data, "replica");
+            break;
+         case SERVER_FAILOVER:
+            data = pgagroal_append(data, "failover");
+            break;
+         case SERVER_FAILED:
+            data = pgagroal_append(data, "failed");
+            break;
+         default:
+            break;
+      }
+
+      data = pgagroal_append(data, "\"} ");
+
+      data = pgagroal_append_ulong(data, atomic_load(&prometheus->server_resume_total[i]));
+      data = pgagroal_append(data, "\n");
+   }
+   if (data != NULL)
+   {
+      add_metric_to_art(container->general_metrics, "pgagroal_server_resume_total", data, NULL, NULL, 0);
+      free(data);
+      data = NULL;
+   }
+
    data = pgagroal_append(data, "#HELP pgagroal_server_streaming Whether a standby is actively streaming from its primary (-1=primary, 0=no, 1=yes)\n");
    data = pgagroal_append(data, "#TYPE pgagroal_server_streaming gauge\n");
    FOREACH_VALID_SERVER
@@ -2542,6 +2766,75 @@ general_information(prometheus_metrics_container_t* container)
       data = pgagroal_append(data, "\n");
    }
    data = pgagroal_append(data, "\n");
+
+   /* Pause metrics are derived from authoritative state:
+    *   - paused  : explicit bool on struct server
+    *   - pending : count of STATE_IN_USE slots on a paused server
+    * A server is fully drained when paused with pending == 0. */
+   {
+      int pending_per_server[NUMBER_OF_SERVERS];
+
+      for (int s = 0; s < config->number_of_servers; s++)
+      {
+         pending_per_server[s] = 0;
+      }
+      for (int i = 0; i < config->max_connections; i++)
+      {
+         int srv = config->connections[i].server;
+         if (srv >= 0 && srv < config->number_of_servers &&
+             config->servers[srv].paused &&
+             atomic_load(&config->states[i]) == STATE_IN_USE)
+         {
+            pending_per_server[srv]++;
+         }
+      }
+
+      data = pgagroal_append(data, "#HELP pgagroal_server_pause_state The pause state of the server (0 = running, 1 = paused)\n");
+      data = pgagroal_append(data, "#TYPE pgagroal_server_pause_state gauge\n");
+      FOREACH_VALID_SERVER
+      {
+         int v = config->servers[i].paused ? 1 : 0;
+         data = pgagroal_append(data, "pgagroal_server_pause_state{name=\"");
+         data = pgagroal_append(data, config->servers[i].name);
+         data = pgagroal_append(data, "\"} ");
+         data = pgagroal_append_int(data, v);
+         data = pgagroal_append(data, "\n");
+      }
+      add_metric_to_art(container->general_metrics, "pgagroal_server_pause_state", data, NULL, NULL, 0);
+      free(data);
+      data = NULL;
+
+      data = pgagroal_append(data, "#HELP pgagroal_pause_pending_active_connections Slots still STATE_IN_USE on a paused server\n");
+      data = pgagroal_append(data, "#TYPE pgagroal_pause_pending_active_connections gauge\n");
+      FOREACH_VALID_SERVER
+      {
+         data = pgagroal_append(data, "pgagroal_pause_pending_active_connections{name=\"");
+         data = pgagroal_append(data, config->servers[i].name);
+         data = pgagroal_append(data, "\"} ");
+         data = pgagroal_append_int(data, pending_per_server[i]);
+         data = pgagroal_append(data, "\n");
+      }
+      add_metric_to_art(container->general_metrics, "pgagroal_pause_pending_active_connections", data, NULL, NULL, 0);
+      free(data);
+      data = NULL;
+
+      /* Unix timestamp of the current pause (0 when the server is running).
+       * Duration is derived in PromQL: time() - pgagroal_server_last_paused_timestamp. */
+      data = pgagroal_append(data, "#HELP pgagroal_server_last_paused_timestamp Unix time when the server was paused (0 if running)\n");
+      data = pgagroal_append(data, "#TYPE pgagroal_server_last_paused_timestamp gauge\n");
+      FOREACH_VALID_SERVER
+      {
+         uint64_t ts = config->servers[i].paused ? (uint64_t)config->servers[i].last_paused : 0;
+         data = pgagroal_append(data, "pgagroal_server_last_paused_timestamp{name=\"");
+         data = pgagroal_append(data, config->servers[i].name);
+         data = pgagroal_append(data, "\"} ");
+         data = pgagroal_append_ulong(data, ts);
+         data = pgagroal_append(data, "\n");
+      }
+      add_metric_to_art(container->general_metrics, "pgagroal_server_last_paused_timestamp", data, NULL, NULL, 0);
+      free(data);
+      data = NULL;
+   }
 
    data = pgagroal_append(data, "#HELP pgagroal_wait_time The waiting time of clients\n");
    data = pgagroal_append(data, "#TYPE pgagroal_wait_time gauge\n");

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -645,6 +645,166 @@ error:
 }
 
 int
+pgagroal_reauth_slot(int slot, SSL** server_ssl)
+{
+   int server_fd = -1;
+   int auth_type = -1;
+   signed char server_state;
+   struct main_configuration* config = NULL;
+   struct message* startup_msg = NULL;
+   struct message* msg = NULL;
+   int status = -1;
+   int ret = -1;
+   char* username = NULL;
+   char* database = NULL;
+   char* password = NULL;
+   int server = -1;
+
+   config = (struct main_configuration*)shmem;
+
+   /* Free any existing server TLS context before overwriting the pointer */
+   if (*server_ssl != NULL)
+   {
+      pgagroal_close_ssl(*server_ssl);
+   }
+   *server_ssl = NULL;
+
+   if (slot < 0 || slot >= config->max_connections)
+   {
+      return AUTH_ERROR;
+   }
+
+   username = (char*)&config->connections[slot].username;
+   database = (char*)&config->connections[slot].database;
+   server = config->connections[slot].server;
+
+   if (server < 0)
+   {
+      pgagroal_log_warn("reauth_slot: slot %d has no server bound", slot);
+      return AUTH_ERROR;
+   }
+   password = get_frontend_password(username);
+   if (password == NULL)
+   {
+      password = pgagroal_get_user_password(username);
+   }
+
+   if (password == NULL)
+   {
+      pgagroal_log_info("reauth_slot: user '%s' not found in configurations; cannot silently reauth slot %d", username, slot);
+      return AUTH_ERROR;
+   }
+
+   if (config->servers[server].host[0] == '/')
+   {
+      char pgsql[MISC_LENGTH];
+
+      memset(&pgsql, 0, sizeof(pgsql));
+      snprintf(&pgsql[0], sizeof(pgsql), ".s.PGSQL.%d", config->servers[server].port);
+      ret = pgagroal_connect_unix_socket(config->servers[server].host, &pgsql[0], &server_fd);
+   }
+   else
+   {
+      ret = pgagroal_connect(config->servers[server].host, config->servers[server].port, &server_fd, config->keep_alive, config->nodelay);
+   }
+
+   if (ret)
+   {
+      pgagroal_log_error("reauth_slot: no connection to %s:%d for slot %d",
+                         config->servers[server].host, config->servers[server].port, slot);
+      goto error;
+   }
+
+   config->connections[slot].fd = server_fd;
+   config->connections[slot].has_security = SECURITY_INVALID;
+   for (int i = 0; i < NUMBER_OF_SECURITY_MESSAGES; i++)
+   {
+      config->connections[slot].security_lengths[i] = 0;
+      memset(&config->connections[slot].security_messages[i], 0, SECURITY_BUFFER_SIZE);
+   }
+   config->connections[slot].backend_pid = 0;
+   config->connections[slot].backend_secret = 0;
+
+   if (establish_client_tls_connection(server, server_fd, server_ssl) != AUTH_SUCCESS)
+   {
+      pgagroal_log_error("reauth_slot: TLS negotiation failed for slot %d (server %d)", slot, server);
+      goto error;
+   }
+
+   status = pgagroal_create_startup_message(username, database, &startup_msg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      goto error;
+   }
+
+   status = pgagroal_write_message(*server_ssl, server_fd, startup_msg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      goto error;
+   }
+
+   status = pgagroal_read_block_message(*server_ssl, server_fd, &msg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      goto error;
+   }
+
+   get_auth_type(msg, &auth_type);
+   pgagroal_log_trace("reauth_slot: auth type %d", auth_type);
+
+   if (auth_type == -1)
+   {
+      goto error;
+   }
+   if (auth_type != SECURITY_TRUST && auth_type != SECURITY_PASSWORD && auth_type != SECURITY_SCRAM256)
+   {
+      goto error;
+   }
+
+   if (server_authenticate(msg, auth_type, username, password, slot, *server_ssl))
+   {
+      goto error;
+   }
+
+   server_state = atomic_load(&config->servers[server].state);
+   if (server_state == SERVER_NOTINIT || server_state == SERVER_NOTINIT_PRIMARY)
+   {
+      pgagroal_update_server_state(slot, server_fd, *server_ssl);
+      pgagroal_server_status();
+   }
+
+   pgagroal_log_debug("reauth_slot: SUCCESS slot=%d user=%s db=%s server=%d fd=%d",
+                      slot, username, database, server, server_fd);
+
+   atomic_store(&config->states[slot], STATE_IN_USE);
+
+   pgagroal_free_message(startup_msg);
+   pgagroal_clear_message(msg);
+
+   return AUTH_SUCCESS;
+
+error:
+   pgagroal_log_debug("reauth_slot: ERROR slot=%d", slot);
+
+   if (*server_ssl != NULL)
+   {
+      pgagroal_close_ssl(*server_ssl);
+      *server_ssl = NULL;
+   }
+
+   if (server_fd != -1)
+   {
+      pgagroal_disconnect(server_fd);
+      config->connections[slot].fd = -1;
+   }
+
+   pgagroal_free_message(startup_msg);
+   pgagroal_clear_message(msg);
+
+   return AUTH_ERROR;
+}
+
+int
 pgagroal_remote_management_auth(int client_fd, char* address, SSL** client_ssl)
 {
    int status = MESSAGE_STATUS_ERROR;

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -646,6 +646,166 @@ error:
 }
 
 int
+pgagroal_reauth_slot(int slot, SSL** server_ssl)
+{
+   int server_fd = -1;
+   int auth_type = -1;
+   signed char server_state;
+   struct main_configuration* config = NULL;
+   struct message* startup_msg = NULL;
+   struct message* msg = NULL;
+   int status = -1;
+   int ret = -1;
+   char* username = NULL;
+   char* database = NULL;
+   char* password = NULL;
+   int server = -1;
+
+   config = (struct main_configuration*)shmem;
+
+   /* Free any existing server TLS context before overwriting the pointer */
+   if (*server_ssl != NULL)
+   {
+      pgagroal_close_ssl(*server_ssl);
+   }
+   *server_ssl = NULL;
+
+   if (slot < 0 || slot >= config->max_connections)
+   {
+      return AUTH_ERROR;
+   }
+
+   username = (char*)&config->connections[slot].username;
+   database = (char*)&config->connections[slot].database;
+   server = config->connections[slot].server;
+
+   if (server < 0)
+   {
+      pgagroal_log_warn("reauth_slot: slot %d has no server bound", slot);
+      return AUTH_ERROR;
+   }
+   password = get_frontend_password(username);
+   if (password == NULL)
+   {
+      password = pgagroal_get_user_password(username);
+   }
+
+   if (password == NULL)
+   {
+      pgagroal_log_info("reauth_slot: user '%s' not found in configurations; cannot silently reauth slot %d", username, slot);
+      return AUTH_ERROR;
+   }
+
+   if (config->servers[server].host[0] == '/')
+   {
+      char pgsql[MISC_LENGTH];
+
+      memset(&pgsql, 0, sizeof(pgsql));
+      snprintf(&pgsql[0], sizeof(pgsql), ".s.PGSQL.%d", config->servers[server].port);
+      ret = pgagroal_connect_unix_socket(config->servers[server].host, &pgsql[0], &server_fd);
+   }
+   else
+   {
+      ret = pgagroal_connect(config->servers[server].host, config->servers[server].port, &server_fd, config->keep_alive, config->nodelay);
+   }
+
+   if (ret)
+   {
+      pgagroal_log_error("reauth_slot: no connection to %s:%d for slot %d",
+                         config->servers[server].host, config->servers[server].port, slot);
+      goto error;
+   }
+
+   config->connections[slot].fd = server_fd;
+   config->connections[slot].has_security = SECURITY_INVALID;
+   for (int i = 0; i < NUMBER_OF_SECURITY_MESSAGES; i++)
+   {
+      config->connections[slot].security_lengths[i] = 0;
+      memset(&config->connections[slot].security_messages[i], 0, SECURITY_BUFFER_SIZE);
+   }
+   config->connections[slot].backend_pid = 0;
+   config->connections[slot].backend_secret = 0;
+
+   if (establish_client_tls_connection(server, server_fd, server_ssl) != AUTH_SUCCESS)
+   {
+      pgagroal_log_error("reauth_slot: TLS negotiation failed for slot %d (server %d)", slot, server);
+      goto error;
+   }
+
+   status = pgagroal_create_startup_message(username, database, &startup_msg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      goto error;
+   }
+
+   status = pgagroal_write_message(*server_ssl, server_fd, startup_msg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      goto error;
+   }
+
+   status = pgagroal_read_block_message(*server_ssl, server_fd, &msg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      goto error;
+   }
+
+   get_auth_type(msg, &auth_type);
+   pgagroal_log_trace("reauth_slot: auth type %d", auth_type);
+
+   if (auth_type == -1)
+   {
+      goto error;
+   }
+   if (auth_type != SECURITY_TRUST && auth_type != SECURITY_PASSWORD && auth_type != SECURITY_SCRAM256)
+   {
+      goto error;
+   }
+
+   if (server_authenticate(msg, auth_type, username, password, slot, *server_ssl))
+   {
+      goto error;
+   }
+
+   server_state = atomic_load(&config->servers[server].state);
+   if (server_state == SERVER_NOTINIT || server_state == SERVER_NOTINIT_PRIMARY)
+   {
+      pgagroal_update_server_state(slot, server_fd, *server_ssl);
+      pgagroal_server_status();
+   }
+
+   pgagroal_log_debug("reauth_slot: SUCCESS slot=%d user=%s db=%s server=%d fd=%d",
+                      slot, username, database, server, server_fd);
+
+   atomic_store(&config->states[slot], STATE_IN_USE);
+
+   pgagroal_free_message(startup_msg);
+   pgagroal_clear_message(msg);
+
+   return AUTH_SUCCESS;
+
+error:
+   pgagroal_log_debug("reauth_slot: ERROR slot=%d", slot);
+
+   if (*server_ssl != NULL)
+   {
+      pgagroal_close_ssl(*server_ssl);
+      *server_ssl = NULL;
+   }
+
+   if (server_fd != -1)
+   {
+      pgagroal_disconnect(server_fd);
+      config->connections[slot].fd = -1;
+   }
+
+   pgagroal_free_message(startup_msg);
+   pgagroal_clear_message(msg);
+
+   return AUTH_ERROR;
+}
+
+int
 pgagroal_remote_management_auth(int client_fd, char* address, SSL** client_ssl)
 {
    int status = MESSAGE_STATUS_ERROR;

--- a/src/libpgagroal/status.c
+++ b/src/libpgagroal/status.c
@@ -191,6 +191,7 @@ status_details(bool details, struct json* response)
    pgagroal_json_put(response, MANAGEMENT_ARGUMENT_MAX_CONNECTIONS, (uintptr_t)config->max_connections, ValueUInt32);
 
    pgagroal_json_put(response, MANAGEMENT_ARGUMENT_NUMBER_OF_SERVERS, (uintptr_t)config->number_of_servers, ValueInt32);
+   pgagroal_json_put(response, MANAGEMENT_ARGUMENT_ALL_PAUSED, (uintptr_t)config->all_paused, ValueBool);
 
    pgagroal_json_create(&servers);
 
@@ -228,6 +229,15 @@ status_details(bool details, struct json* response)
       pgagroal_json_put(js, MANAGEMENT_ARGUMENT_PRIMARY, (uintptr_t)srv_primary, ValueString);
       if (behind_bytes >= 0)
          pgagroal_json_put(js, MANAGEMENT_ARGUMENT_BEHIND, (uintptr_t)behind_bytes, ValueInt64);
+
+      char last_paused[MISC_LENGTH];
+      char last_resumed[MISC_LENGTH];
+
+      pgagroal_json_put(js, MANAGEMENT_ARGUMENT_PAUSED, (uintptr_t)config->servers[i].paused, ValueBool);
+      pgagroal_management_format_timestamp(config->servers[i].last_paused, last_paused, sizeof(last_paused));
+      pgagroal_management_format_timestamp(config->servers[i].last_resumed, last_resumed, sizeof(last_resumed));
+      pgagroal_json_put(js, MANAGEMENT_ARGUMENT_LAST_PAUSED, (uintptr_t)last_paused, ValueString);
+      pgagroal_json_put(js, MANAGEMENT_ARGUMENT_LAST_RESUMED, (uintptr_t)last_resumed, ValueString);
 
       pgagroal_json_put(servers, config->servers[i].name, (uintptr_t)js, ValueJSON);
    }

--- a/src/libpgagroal/status.c
+++ b/src/libpgagroal/status.c
@@ -192,6 +192,7 @@ status_details(bool details, struct json* response)
    pgagroal_json_put(response, MANAGEMENT_ARGUMENT_MAX_CONNECTIONS, (uintptr_t)config->max_connections, ValueUInt32);
 
    pgagroal_json_put(response, MANAGEMENT_ARGUMENT_NUMBER_OF_SERVERS, (uintptr_t)config->number_of_servers, ValueInt32);
+   pgagroal_json_put(response, MANAGEMENT_ARGUMENT_ALL_PAUSED, (uintptr_t)config->all_paused, ValueBool);
 
    pgagroal_json_create(&servers);
    pgagroal_json_create(&standbys);
@@ -235,6 +236,15 @@ status_details(bool details, struct json* response)
       pgagroal_json_put(js, MANAGEMENT_ARGUMENT_PRIMARY, (uintptr_t)srv_primary, ValueString);
       if (behind_bytes >= 0)
          pgagroal_json_put(js, MANAGEMENT_ARGUMENT_BEHIND, (uintptr_t)behind_bytes, ValueInt64);
+
+      char last_paused[MISC_LENGTH];
+      char last_resumed[MISC_LENGTH];
+
+      pgagroal_json_put(js, MANAGEMENT_ARGUMENT_PAUSED, (uintptr_t)config->servers[i].paused, ValueBool);
+      pgagroal_management_format_timestamp(config->servers[i].last_paused, last_paused, sizeof(last_paused));
+      pgagroal_management_format_timestamp(config->servers[i].last_resumed, last_resumed, sizeof(last_resumed));
+      pgagroal_json_put(js, MANAGEMENT_ARGUMENT_LAST_PAUSED, (uintptr_t)last_paused, ValueString);
+      pgagroal_json_put(js, MANAGEMENT_ARGUMENT_LAST_RESUMED, (uintptr_t)last_resumed, ValueString);
 
       pgagroal_json_put(servers, config->servers[i].name, (uintptr_t)js, ValueJSON);
 

--- a/src/libpgagroal/worker.c
+++ b/src/libpgagroal/worker.c
@@ -52,16 +52,21 @@
 volatile int exit_code = WORKER_FAILURE;
 
 static void signal_callback(void);
+static void pause_callback(void);
+static void resume_callback(void);
 
 void
 pgagroal_worker(int client_fd, char* address, char** argv)
 {
    struct event_loop* loop = NULL;
    struct signal_info signal_watcher;
+   struct signal_info pause_watcher;
+   struct signal_info resume_watcher;
    struct worker_io client_io;
    struct worker_io server_io;
    time_t start_time;
    bool started = false;
+   bool paused = false;
    int auth_status;
    struct main_configuration* config;
    struct pipeline p;
@@ -172,6 +177,14 @@ pgagroal_worker(int client_fd, char* address, char** argv)
       signal_watcher.slot = slot;
       pgagroal_signal_start(&signal_watcher.sig_w);
 
+      pgagroal_signal_init(&pause_watcher.sig_w, pause_callback, SIGUSR1);
+      pause_watcher.slot = slot;
+      pgagroal_signal_start(&pause_watcher.sig_w);
+
+      pgagroal_signal_init(&resume_watcher.sig_w, resume_callback, SIGUSR2);
+      resume_watcher.slot = slot;
+      pgagroal_signal_start(&resume_watcher.sig_w);
+
       p.start(loop, &client_io);
       started = true;
 
@@ -181,8 +194,84 @@ pgagroal_worker(int client_fd, char* address, char** argv)
          pgagroal_io_start(&server_io.io);
       }
 
-      pgagroal_event_loop_run();
+      while (true)
+      {
+         pgagroal_event_loop_run();
+         if (exit_code == WORKER_PAUSED)
+         {
+            if (paused)
+            {
+               exit_code = WORKER_FAILURE;
+               continue;
+            }
+            paused = true;
+            pgagroal_io_pause(&client_io.io);
+            pgagroal_log_debug("pgagroal_worker: slot %d paused", slot);
+            exit_code = WORKER_FAILURE;
+         }
+         else if (exit_code == WORKER_RESUME)
+         {
+            if (!paused)
+            {
+               exit_code = WORKER_FAILURE;
+               continue;
+            }
+            pgagroal_log_debug("pgagroal_worker: slot %d resuming", slot);
+            paused = false;
 
+            if (pgagroal_socket_isvalid(config->connections[slot].fd))
+            {
+               pgagroal_log_debug("pgagroal_worker: slot %d backend alive", slot);
+            }
+            else
+            {
+               pgagroal_log_debug("pgagroal_worker: slot %d backend gone, reauthenticating", slot);
+
+               if (config->pipeline != PIPELINE_TRANSACTION)
+               {
+                  pgagroal_io_stop(&server_io.io);
+               }
+               pgagroal_disconnect(config->connections[slot].fd);
+
+               if (pgagroal_reauth_slot(slot, &server_ssl) == AUTH_SUCCESS)
+               {
+                  pgagroal_log_debug("pgagroal_worker: slot %d reauth success", slot);
+                  pgagroal_event_worker_init(&client_io.io, client_fd, config->connections[slot].fd, p.client);
+
+                  client_io.server_fd = config->connections[slot].fd;
+                  client_io.server_ssl = server_ssl;
+
+                  if (config->pipeline != PIPELINE_TRANSACTION)
+                  {
+                     pgagroal_event_worker_init(&server_io.io, config->connections[slot].fd, client_fd, p.server);
+                     server_io.client_fd = client_fd;
+                     server_io.server_fd = config->connections[slot].fd;
+                     server_io.slot = slot;
+                     server_io.client_ssl = client_ssl;
+                     server_io.server_ssl = server_ssl;
+                     pgagroal_io_start(&server_io.io);
+                  }
+               }
+               else
+               {
+                  pgagroal_log_error("pgagroal_worker: slot %d reauth failed", slot);
+                  exit_code = WORKER_SERVER_FAILURE;
+                  break;
+               }
+            }
+
+            pgagroal_io_resume(&client_io.io);
+
+            pgagroal_log_info("resume: signalling worker for slot %d (pid %d)",
+                              slot, config->connections[slot].pid);
+            exit_code = WORKER_FAILURE;
+            continue;
+         }
+         else
+         {
+            break; /* real exit */
+         }
+      }
       if (config->pipeline == PIPELINE_TRANSACTION)
       {
          /* The slot may have been updated */
@@ -325,5 +414,19 @@ static void
 signal_callback(void)
 {
    exit_code = WORKER_SHUTDOWN;
+   pgagroal_event_loop_break();
+}
+
+static void
+pause_callback(void)
+{
+   exit_code = WORKER_PAUSED;
+   pgagroal_event_loop_break();
+}
+
+static void
+resume_callback(void)
+{
+   exit_code = WORKER_RESUME;
    pgagroal_event_loop_break();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -98,6 +98,9 @@ static void shutdown_timeout_cb(void);
 static void flush_alarm_cb(void);
 static void arm_flush_timeout(int64_t seconds, const char* database);
 static void rearm_flush_alarm(void);
+static void arm_pause_timeout(int64_t seconds, const char* server);
+static void rearm_pause_alarm(void);
+static void pause_alarm_cb(void);
 static void frontend_user_password_startup(struct main_configuration* config);
 static bool accept_fatal(int error);
 static void add_client(pid_t pid);
@@ -144,6 +147,9 @@ static struct periodic_watcher rotate_frontend_password_watcher;
 static struct periodic_watcher shutdown_timeout_watcher;
 static struct periodic_watcher flush_alarm;
 static struct flush_timeout_slot flush_timeouts[NUMBER_OF_LIMITS];
+static struct periodic_watcher pause_alarm;
+static bool pause_alarm_started = false;
+static struct pause_timeout_slot pause_timeouts[NUMBER_OF_SERVERS];
 static bool idle_timeout_started = false;
 static bool max_connection_age_started = false;
 static bool validation_started = false;
@@ -1862,6 +1868,112 @@ accept_mgt_cb(struct io_watcher* watcher)
 
       pgagroal_management_response_ok(NULL, client_fd, start_time, end_time, compression, encryption, payload);
    }
+   else if (id == MANAGEMENT_PAUSE)
+   {
+      struct json* req = NULL;
+      int64_t req_timeout = -1;
+      int32_t req_mode = PAUSE_MODE_GRACEFULLY;
+      char* req_server = NULL;
+
+      pgagroal_log_debug("pgagroal: Management pause");
+      pgagroal_pool_status();
+
+      req = (struct json*)pgagroal_json_get(payload, MANAGEMENT_CATEGORY_REQUEST);
+      if (req != NULL)
+      {
+         if (pgagroal_json_contains_key(req, MANAGEMENT_ARGUMENT_MODE))
+         {
+            req_mode = (int)pgagroal_json_get(req, MANAGEMENT_ARGUMENT_MODE);
+         }
+         if (pgagroal_json_contains_key(req, MANAGEMENT_ARGUMENT_TIMEOUT))
+         {
+            req_timeout = (int64_t)pgagroal_json_get(req, MANAGEMENT_ARGUMENT_TIMEOUT);
+         }
+         req_server = (char*)pgagroal_json_get(req, MANAGEMENT_ARGUMENT_SERVER);
+      }
+
+      pid = fork();
+      if (pid == -1)
+      {
+         pgagroal_management_response_error(NULL, client_fd, NULL, MANAGEMENT_ERROR_PAUSE_NOFORK, compression, encryption, payload);
+         pgagroal_log_error("Pause: No fork (%d)", MANAGEMENT_ERROR_PAUSE_NOFORK);
+         goto error;
+      }
+      else if (pid == 0)
+      {
+         struct json* pyl = NULL;
+
+         shutdown_ports(true);
+
+         pgagroal_json_clone(payload, &pyl);
+
+         pgagroal_set_proc_title(1, ai->argv, "pause", NULL);
+         pgagroal_request_pause(NULL, client_fd, compression, encryption, pyl);
+      }
+      else
+      {
+         if (req_mode == PAUSE_MODE_GRACEFULLY)
+         {
+            int64_t conf_secs = pgagroal_time_is_valid(config->flush_timeout)
+                                   ? pgagroal_time_convert(config->flush_timeout, FORMAT_TIME_S)
+                                   : 0;
+            int64_t secs = (req_timeout >= 0) ? req_timeout : conf_secs;
+            if (secs > 0 && atomic_load(&config->active_connections) > 0)
+            {
+               arm_pause_timeout(secs, req_server);
+            }
+         }
+      }
+   }
+   else if (id == MANAGEMENT_RESUME)
+   {
+      struct json* req = NULL;
+      struct json* pyl = NULL;
+      char* server = NULL;
+      req = (struct json*)pgagroal_json_get(payload, MANAGEMENT_CATEGORY_REQUEST);
+      server = (char*)pgagroal_json_get(req, MANAGEMENT_ARGUMENT_SERVER);
+
+      pid = fork();
+
+      if (pid == -1)
+      {
+         pgagroal_management_response_error(NULL, client_fd, NULL, MANAGEMENT_ERROR_RESUME_NOFORK, compression, encryption, payload);
+         pgagroal_log_error("Resume: No fork (%d)", MANAGEMENT_ERROR_RESUME_NOFORK);
+         goto error;
+      }
+      else if (pid == 0)
+      {
+         shutdown_ports(true);
+
+         pgagroal_json_clone(payload, &pyl);
+         pgagroal_set_proc_title(1, ai->argv, "resume", NULL);
+         pgagroal_request_resume(NULL, client_fd, compression, encryption, pyl);
+      }
+      else
+      {
+         /* Disarm any pending pause timeouts for the resumed server(s) */
+         for (int i = 0; i < NUMBER_OF_SERVERS; i++)
+         {
+            if (!pause_timeouts[i].in_use)
+            {
+               continue;
+            }
+            /* If resuming all ("*" or NULL), clear everything;
+             * otherwise clear the matching server or any global ("*") timeout
+             * to prevent it from forcing a pause on the resumed server later. */
+            if (server == NULL || !strcmp(server, "*") ||
+                !strcmp(pause_timeouts[i].server, server) ||
+                !strcmp(pause_timeouts[i].server, "*"))
+            {
+               pgagroal_log_debug("Resume: disarming pause timeout slot %d (server='%s')",
+                                  i, pause_timeouts[i].server);
+               pause_timeouts[i].in_use = false;
+               memset(pause_timeouts[i].server, 0, sizeof(pause_timeouts[i].server));
+            }
+         }
+         rearm_pause_alarm();
+      }
+   }
    else if (id == MANAGEMENT_GRACEFULLY)
    {
       struct json* req = NULL;
@@ -2908,6 +3020,91 @@ flush_alarm_cb(void)
 }
 
 static void
+pause_alarm_cb(void)
+{
+   struct timespec now;
+   struct main_configuration* config;
+   bool fired = false;
+
+   config = (struct main_configuration*)shmem;
+
+   stop_periodic_watcher(&pause_alarm, &pause_alarm_started);
+
+   clock_gettime(CLOCK_MONOTONIC, &now);
+
+   for (int i = 0; i < NUMBER_OF_SERVERS; i++)
+   {
+      char srv[MISC_LENGTH];
+
+      if (!pause_timeouts[i].in_use)
+      {
+         continue;
+      }
+
+      if (pause_timeouts[i].expires_at.tv_sec > now.tv_sec ||
+          (pause_timeouts[i].expires_at.tv_sec == now.tv_sec &&
+           pause_timeouts[i].expires_at.tv_nsec > now.tv_nsec))
+      {
+         continue;
+      }
+
+      memcpy(srv, pause_timeouts[i].server, sizeof(srv));
+      pause_timeouts[i].in_use = false;
+      memset(pause_timeouts[i].server, 0, sizeof(pause_timeouts[i].server));
+
+      if (srv[0] == '\0' || !strcmp(srv, "*"))
+      {
+         if (!config->all_paused)
+         {
+            pgagroal_log_debug("pause_alarm_cb: all servers already resumed, skipping");
+            continue;
+         }
+      }
+      else
+      {
+         bool still_paused = false;
+         for (int s = 0; s < config->number_of_servers; s++)
+         {
+            if (!strcmp(config->servers[s].name, srv) && config->servers[s].paused)
+            {
+               still_paused = true;
+               break;
+            }
+         }
+         if (!still_paused)
+         {
+            pgagroal_log_debug("pause_alarm_cb: server '%s' already resumed, skipping", srv);
+            continue;
+         }
+      }
+
+      if (atomic_load(&config->active_connections) > 0)
+      {
+         fired = true;
+
+         pgagroal_log_warn("pgagroal: pause timeout expired - forcing PAUSE_MODE_ALL on server '%s'",
+                           srv[0] ? srv : "*");
+         if (!fork())
+         {
+            pgagroal_pause(PAUSE_MODE_ALL, srv[0] ? srv : "*");
+            exit(0);
+         }
+      }
+      else
+      {
+         pgagroal_log_info("pgagroal: pause timeout fired but no active connections remain, skipping");
+      }
+   }
+
+   if (fired)
+   {
+      pgagroal_pool_status();
+   }
+
+   rearm_pause_alarm();
+}
+
+static void
 rotate_frontend_password_cb(void)
 {
    char* pwd;
@@ -3173,6 +3370,105 @@ rearm_flush_alarm(void)
 
    start_periodic_watcher(&flush_alarm, &flush_alarm_started,
                           flush_alarm_cb,
+                          delta_ms,
+                          0);
+}
+
+static void
+arm_pause_timeout(int64_t seconds, const char* server)
+{
+   const char* srv = (server != NULL && server[0] != '\0') ? server : "*";
+   int slot = -1;
+
+   if (seconds <= 0)
+   {
+      return;
+   }
+   for (int i = 0; i < NUMBER_OF_SERVERS; i++)
+   {
+      if (pause_timeouts[i].in_use && !strcmp(pause_timeouts[i].server, srv))
+      {
+         slot = i;
+         break;
+      }
+   }
+   if (slot < 0)
+   {
+      for (int i = 0; i < NUMBER_OF_SERVERS; i++)
+      {
+         if (!pause_timeouts[i].in_use)
+         {
+            slot = i;
+            break;
+         }
+      }
+   }
+   if (slot < 0)
+   {
+      pgagroal_log_warn("pgagroal: pause timeout table full - proceeding unbounded for '%s'", srv);
+      return;
+   }
+
+   pause_timeouts[slot].in_use = true;
+   memset(pause_timeouts[slot].server, 0, sizeof(pause_timeouts[slot].server));
+   strncpy(pause_timeouts[slot].server, srv, sizeof(pause_timeouts[slot].server) - 1);
+   clock_gettime(CLOCK_MONOTONIC, &pause_timeouts[slot].expires_at);
+   pause_timeouts[slot].expires_at.tv_sec += seconds;
+
+   rearm_pause_alarm();
+
+   if (!pause_alarm_started)
+   {
+      pgagroal_log_warn("pgagroal: failed to arm pause alarm watcher");
+      pause_timeouts[slot].in_use = false;
+      memset(pause_timeouts[slot].server, 0, sizeof(pause_timeouts[slot].server));
+      return;
+   }
+
+   pgagroal_log_info("pgagroal: pause timeout armed (%llds, server=%s)",
+                     (long long)seconds, srv);
+}
+
+static void
+rearm_pause_alarm(void)
+{
+   struct timespec now;
+   struct timespec earliest = {0};
+   bool have_earliest = false;
+   int64_t delta_ms;
+
+   for (int i = 0; i < NUMBER_OF_SERVERS; i++)
+   {
+      if (!pause_timeouts[i].in_use)
+      {
+         continue;
+      }
+      if (!have_earliest ||
+          pause_timeouts[i].expires_at.tv_sec < earliest.tv_sec ||
+          (pause_timeouts[i].expires_at.tv_sec == earliest.tv_sec &&
+           pause_timeouts[i].expires_at.tv_nsec < earliest.tv_nsec))
+      {
+         earliest = pause_timeouts[i].expires_at;
+         have_earliest = true;
+      }
+   }
+
+   if (!have_earliest)
+   {
+      stop_periodic_watcher(&pause_alarm, &pause_alarm_started);
+      return;
+   }
+
+   clock_gettime(CLOCK_MONOTONIC, &now);
+   delta_ms = ((int64_t)(earliest.tv_sec - now.tv_sec)) * 1000 + ((int64_t)(earliest.tv_nsec - now.tv_nsec)) / 1000000;
+
+   if (delta_ms <= 0)
+   {
+      delta_ms = 1;
+   }
+
+   start_periodic_watcher(&pause_alarm, &pause_alarm_started,
+                          pause_alarm_cb,
                           delta_ms,
                           0);
 }


### PR DESCRIPTION
# [#844] Add Pause and Resume Feature

## Overview
closes #844 
Follwing what we disscussed in [#890]. 
Implementing graceful and forced connection pool pausing and resuming for  `pgagroal`. It introduces the ability to suspend client traffic temporarily without dropping them, and seamlessly re-authenticates dead backend connections upon resumption if the database restarted while paused.

`pgagroal-cli pause [gracefully|all] [<server>|*] --timeout `
`pgagroal-cli resume [<server>|*]`


## Implementation Details

* **Worker Signal Handling (`worker.c`)**:
  * Rewrote the worker's execution flow by wrapping `pgagroal_event_loop_run()` in a `while (true)` state machine.
  * Mapped `SIGUSR1` to `pause_callback` (`WORKER_PAUSED`) and `SIGUSR2` to `resume_callback` (`WORKER_RESUME`).
  * When paused, it explicitly calls `pgagroal_io_pause(&client_io.io)` to halt reading from the client, holding them in suspense.

* **Re-authentication on Resume (`worker.c`)**:
  * When resuming, the worker actively checks if the backend is still alive using `pgagroal_socket_isvalid()`.
  * If the database backend died (e.g., from a DB restart during the pause), the worker drops the dead socket and calls `pgagroal_reauth_slot()` to transparently re-authenticate the client to a new backend connection, re-binding the event loop cleanly.

* **Cancel Requests (`pool.c`)**:
  * In `PAUSE_MODE_ALL`, the pool actively connects to the backend using a temporary socket (UNIX or TCP depending on config) and sends a PostgreSQL `CancelRequest`.
  * Immediately after sending the cancel message, it issues `kill(pid, SIGUSR1)` to force the worker into the paused state.
  * In `PAUSE_MODE_GRACEFULLY`, it simply lets active transactions finish naturally with timeout. 

