### PR TITLE
Harden file handling

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -637,8 +637,7 @@ add_user(char* users_path, char* username, char* password, bool generate_pwd, in
       do_free = false;
    }
 
-   users_file = fopen(users_path, "a+");
-   if (users_file == NULL)
+   if (pgagroal_fopen_secure(users_path, "a+", &users_file))
    {
       warnx("Could not append to users file <%s>", users_path);
       goto error;
@@ -957,18 +956,24 @@ update_user(char* users_path, char* username, char* password, bool generate_pwd,
       do_free = false;
    }
 
-   users_file = fopen(users_path, "r");
-   if (!users_file)
+   if (pgagroal_fopen_secure(users_path, "r", &users_file))
    {
       warnx("File <%s> not found", users_path);
       goto error;
    }
 
-   pgagroal_snprintf(tmpfilename, sizeof(tmpfilename), "%s.tmp", users_path);
-   users_file_tmp = fopen(tmpfilename, "w+");
+   pgagroal_snprintf(tmpfilename, sizeof(tmpfilename), "%s.XXXXXX", users_path);
+   int tmp_fd = mkstemp(tmpfilename);
+   if (tmp_fd == -1)
+   {
+      warnx("Could not create temporary user file <%s>", tmpfilename);
+      goto error;
+   }
+   users_file_tmp = fdopen(tmp_fd, "w+");
    if (users_file_tmp == NULL)
    {
-      warnx("Could not write to temporary user file <%s>", tmpfilename);
+      warnx("Could not open temporary user file <%s>", tmpfilename);
+      close(tmp_fd);
       goto error;
    }
 
@@ -1275,19 +1280,25 @@ remove_user(char* users_path, char* username, int32_t output_format)
       goto error;
    }
 
-   users_file = fopen(users_path, "r");
-   if (!users_file)
+   if (pgagroal_fopen_secure(users_path, "r", &users_file))
    {
       warnx("File <%s> not found", users_path);
       goto error;
    }
 
    memset(&tmpfilename, 0, sizeof(tmpfilename));
-   pgagroal_snprintf(tmpfilename, sizeof(tmpfilename), "%s.tmp", users_path);
-   users_file_tmp = fopen(tmpfilename, "w+");
+   pgagroal_snprintf(tmpfilename, sizeof(tmpfilename), "%s.XXXXXX", users_path);
+   int tmp_fd = mkstemp(tmpfilename);
+   if (tmp_fd == -1)
+   {
+      warnx("Could not create temporary user file <%s>", tmpfilename);
+      goto error;
+   }
+   users_file_tmp = fdopen(tmp_fd, "w+");
    if (users_file_tmp == NULL)
    {
-      warnx("Could not write to temporary user file <%s>", tmpfilename);
+      warnx("Could not open temporary user file <%s>", tmpfilename);
+      close(tmp_fd);
       goto error;
    }
 
@@ -1420,8 +1431,7 @@ list_users(char* users_path, int32_t output_format)
       goto error;
    }
 
-   users_file = fopen(users_path, "r");
-   if (!users_file)
+   if (pgagroal_fopen_secure(users_path, "r", &users_file))
    {
       goto error;
    }
@@ -1500,8 +1510,7 @@ create_response(char* users_path, struct json* json, struct json** response)
       goto error;
    }
 
-   users_file = fopen(users_path, "r");
-   if (!users_file)
+   if (pgagroal_fopen_secure(users_path, "r", &users_file))
    {
       goto error;
    }

--- a/src/config.c
+++ b/src/config.c
@@ -530,7 +530,7 @@ config_init(const char* output_path, bool quiet, bool force)
       }
    }
 
-   file = fopen(tmp_path, "w");
+   pgagroal_fopen_secure(tmp_path, "w", &file);
    if (file == NULL)
    {
       warn("Could not open temp file '%s'", tmp_path);
@@ -686,7 +686,7 @@ config_get(const char* file_path, const char* section, const char* key)
    bool in_section = false;
    char section_header[MISC_LENGTH];
 
-   file = fopen(file_path, "r");
+   pgagroal_fopen_secure(file_path, "r", &file);
    if (file == NULL)
    {
       warnx("Could not open file: %s", file_path);
@@ -812,7 +812,7 @@ config_set(const char* file_path, const char* section, const char* key, const ch
    pgagroal_snprintf(section_header, sizeof(section_header), "[%s]", section);
 
    /* Read all lines */
-   file = fopen(file_path, "r");
+   pgagroal_fopen_secure(file_path, "r", &file);
    if (file != NULL)
    {
       while (fgets(line_buf, sizeof(line_buf), file) != NULL && line_count < MAX_LINES)
@@ -996,7 +996,7 @@ config_set(const char* file_path, const char* section, const char* key, const ch
    pgagroal_snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", file_path);
 
    /* Write all lines back */
-   file = fopen(tmp_path, "w");
+   pgagroal_fopen_secure(tmp_path, "w", &file);
    if (file == NULL)
    {
       warn("Could not open file for writing: %s", tmp_path);
@@ -1077,7 +1077,7 @@ config_del(const char* file_path, const char* section, const char* key)
    memset(lines, 0, sizeof(lines));
    pgagroal_snprintf(section_header, sizeof(section_header), "[%s]", section);
 
-   file = fopen(file_path, "r");
+   pgagroal_fopen_secure(file_path, "r", &file);
    if (file == NULL)
    {
       warnx("Could not open file: %s", file_path);
@@ -1154,7 +1154,7 @@ config_del(const char* file_path, const char* section, const char* key)
    }
 
    pgagroal_snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", file_path);
-   file = fopen(tmp_path, "w");
+   pgagroal_fopen_secure(tmp_path, "w", &file);
    if (file == NULL)
    {
       warn("Could not open temp file for writing: %s", tmp_path);
@@ -1225,7 +1225,7 @@ config_ls(const char* file_path, const char* section)
    bool in_section = false;
    char section_header[MISC_LENGTH] = {0};
 
-   file = fopen(file_path, "r");
+   pgagroal_fopen_secure(file_path, "r", &file);
    if (file == NULL)
    {
       warnx("Could not open file: %s", file_path);

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -314,6 +314,21 @@ bool
 pgagroal_exists(const char* f);
 
 /**
+ * Open a file in a secure way
+ *
+ * Creating, writing or appending adds O_NOFOLLOW, so the last path component
+ * cannot be redirected through a symlink; O_CLOEXEC is always added. A created
+ * file is set to rw------- through the descriptor.
+ *
+ * @param path The path
+ * @param mode The mode, like "w", "wb", "r" or "r+", where an 'x' means exclusive creation
+ * @param file The resulting file
+ * @return 0 upon success, 1 if the file exists and the mode is exclusive, otherwise 2
+ */
+int
+pgagroal_fopen_secure(const char* path, const char* mode, FILE** file);
+
+/**
  * Path is a regular file
  * @param f The path
  * @return The result

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -261,7 +261,7 @@ pgagroal_read_configuration(void* shm, char* filename, bool emit_warnings)
    int lineno = 0;
    int return_value = 0;
 
-   file = fopen(filename, "r");
+   pgagroal_fopen_secure(filename, "r", &file);
 
    if (!file)
    {
@@ -978,7 +978,7 @@ pgagroal_vault_read_configuration(void* shm, char* filename, bool emit_warnings)
    int lineno = 0;
    int return_value = 0;
 
-   file = fopen(filename, "r");
+   pgagroal_fopen_secure(filename, "r", &file);
 
    if (!file)
    {
@@ -1249,7 +1249,7 @@ pgagroal_read_hba_configuration(void* shm, char* filename)
    int lineno = 0;
    struct main_configuration* config;
 
-   file = fopen(filename, "r");
+   pgagroal_fopen_secure(filename, "r", &file);
 
    if (!file)
    {
@@ -1406,7 +1406,7 @@ pgagroal_read_limit_configuration(void* shm, char* filename)
    int lineno;
    struct main_configuration* config;
 
-   file = fopen(filename, "r");
+   pgagroal_fopen_secure(filename, "r", &file);
 
    if (!file)
    {
@@ -1683,7 +1683,7 @@ pgagroal_read_users_configuration(void* shm, char* filename)
    struct main_configuration* config;
    int status;
 
-   file = fopen(filename, "r");
+   pgagroal_fopen_secure(filename, "r", &file);
 
    if (!file)
    {
@@ -1819,7 +1819,7 @@ pgagroal_read_frontend_users_configuration(void* shm, char* filename)
    struct main_configuration* config;
    int status = PGAGROAL_CONFIGURATION_STATUS_OK;
 
-   file = fopen(filename, "r");
+   pgagroal_fopen_secure(filename, "r", &file);
 
    if (!file)
    {
@@ -1980,7 +1980,7 @@ pgagroal_read_admins_configuration(void* shm, char* filename)
    struct main_configuration* config;
    int status = PGAGROAL_CONFIGURATION_STATUS_OK;
 
-   file = fopen(filename, "r");
+   pgagroal_fopen_secure(filename, "r", &file);
 
    if (!file)
    {
@@ -2110,7 +2110,7 @@ pgagroal_vault_read_users_configuration(void* shm, char* filename)
    struct vault_configuration* config;
    int status = PGAGROAL_CONFIGURATION_STATUS_OK;
 
-   file = fopen(filename, "r");
+   pgagroal_fopen_secure(filename, "r", &file);
 
    if (!file)
    {
@@ -2255,7 +2255,7 @@ pgagroal_read_superuser_configuration(void* shm, char* filename)
    struct main_configuration* config;
    int status = PGAGROAL_CONFIGURATION_STATUS_OK;
 
-   file = fopen(filename, "r");
+   pgagroal_fopen_secure(filename, "r", &file);
 
    if (!file)
    {
@@ -7449,7 +7449,7 @@ pgagroal_is_binary_file(const char* path)
    size_t bytes;
    int error;
 
-   fp = fopen(path, "rb");
+   pgagroal_fopen_secure(path, "rb", &fp);
    if (fp == NULL)
    {
       goto error;

--- a/src/libpgagroal/json.c
+++ b/src/libpgagroal/json.c
@@ -719,7 +719,7 @@ pgagroal_json_read_file(char* path, struct json** obj)
       goto error;
    }
 
-   file = fopen(path, "r");
+   pgagroal_fopen_secure(path, "r", &file);
 
    if (file == NULL)
    {
@@ -773,7 +773,7 @@ pgagroal_json_write_file(char* path, struct json* obj)
       goto error;
    }
 
-   file = fopen(path, "wb");
+   pgagroal_fopen_secure(path, "wb", &file);
    if (file == NULL)
    {
       pgagroal_log_error("Failed to create json file %s", path);

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -3585,7 +3585,7 @@ parse_certificate_file(const char* cert_path, struct certificate_info* cert_info
    current_time = cert_info->last_checked;
 
    // Try to open the certificate file
-   fp = fopen(cert_path, "r");
+   pgagroal_fopen_secure(cert_path, "r", &fp);
    if (!fp)
    {
       pgagroal_log_debug("Certificate file not accessible: %s (%s)", cert_path, strerror(errno));

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -3537,7 +3537,7 @@ pgagroal_get_master_key(char** masterkey)
       }
    }
 
-   master_key_file = fopen(&buf[0], "r");
+   pgagroal_fopen_secure(&buf[0], "r", &master_key_file);
    if (master_key_file == NULL)
    {
       goto error;

--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -53,6 +53,7 @@
 #include <execinfo.h>
 #endif
 #include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
 
 extern char** environ;
@@ -580,6 +581,142 @@ pgagroal_exists(const char* f)
    }
 
    return false;
+}
+
+int
+pgagroal_fopen_secure(const char* path, const char* mode, FILE** file)
+{
+   int fd = -1;
+   int flags = 0;
+   int saved_errno = 0;
+   bool create = false;
+   bool read = false;
+   bool write = false;
+   bool append = false;
+   bool plus = false;
+   bool exclusive = false;
+   char fdmode[8];
+   size_t j = 0;
+   const char* p = mode;
+
+   if (file == NULL)
+   {
+      return 2;
+   }
+
+   *file = NULL;
+
+   if (path == NULL || mode == NULL)
+   {
+      return 2;
+   }
+
+   if (strchr(mode, 'r'))
+   {
+      read = true;
+   }
+   if (strchr(mode, 'w'))
+   {
+      write = true;
+      create = true;
+   }
+   if (strchr(mode, 'a'))
+   {
+      append = true;
+      create = true;
+   }
+   if (strchr(mode, '+'))
+   {
+      plus = true;
+   }
+   if (strchr(mode, 'x'))
+   {
+      exclusive = true;
+   }
+
+   if (plus)
+   {
+      flags |= O_RDWR;
+   }
+   else if (read)
+   {
+      flags |= O_RDONLY;
+   }
+   else
+   {
+      flags |= O_WRONLY;
+   }
+
+   if (create)
+   {
+      flags |= O_CREAT;
+      if (write)
+      {
+         flags |= O_TRUNC;
+      }
+      if (exclusive)
+      {
+         flags |= O_EXCL;
+      }
+   }
+
+   if (append)
+   {
+      flags |= O_APPEND;
+   }
+
+   if (create || write || append)
+   {
+      flags |= O_NOFOLLOW;
+   }
+   flags |= O_CLOEXEC;
+
+   if (create)
+   {
+      fd = open(path, flags, S_IRUSR | S_IWUSR);
+   }
+   else
+   {
+      fd = open(path, flags);
+   }
+
+   if (fd == -1)
+   {
+      return errno == EEXIST ? 1 : 2;
+   }
+
+   if (create)
+   {
+      if (fchmod(fd, S_IRUSR | S_IWUSR))
+      {
+         saved_errno = errno;
+         close(fd);
+         errno = saved_errno;
+         return 2;
+      }
+   }
+
+   /* fdopen() only accepts the access part of the mode, 'x' is already O_EXCL */
+   while (*p != '\0' && j < sizeof(fdmode) - 1)
+   {
+      if (*p == 'r' || *p == 'w' || *p == 'a' || *p == 'b' || *p == '+')
+      {
+         fdmode[j++] = *p;
+      }
+      p++;
+   }
+   fdmode[j] = '\0';
+
+   *file = fdopen(fd, fdmode);
+   if (*file == NULL)
+   {
+      saved_errno = errno;
+      close(fd);
+      errno = saved_errno;
+      return 2;
+   }
+
+   return 0;
 }
 
 bool


### PR DESCRIPTION
add pgagroal_fopen_secure (O_NOFOLLOW on create/write/append, O_CLOEXEC always, 0600 perms via fchmod, O_EXCL via 'x' in mode) and route the credential/config file opens through it; use mkstemp for the pgagroal-admin user temp files instead of a predictable .tmp name.