### PR TITLE
[#973] Fix reading split PostgreSQL message headers

### DIFF
--- a/src/include/message.h
+++ b/src/include/message.h
@@ -134,6 +134,85 @@ void
 pgagroal_free_message(struct message* msg);
 
 /**
+ * Callback invoked by pgagroal_parse_message once per complete message boundary.
+ * For messages with a payload it fires when both the header and the first payload
+ * byte have arrived, so the callback can safely read msg[5] (e.g. the transaction
+ * state byte of a ReadyForQuery 'Z' message). A NULL arg is valid; the callback
+ * is responsible for guarding against it if needed.
+ * @param kind The message type byte (e.g. 'Z', 'E', 'D')
+ * @param msg Pointer to the message start (kind byte included); at least 6 bytes
+ *            are valid when msglen > 5
+ * @param msglen Declared total length of the message (kind byte + 4-byte length field + payload)
+ * @param arg Caller-supplied context passed through unchanged from pgagroal_parse_message
+ */
+typedef void (*pgagroal_message_callback)(char kind, char* msg, int msglen, void* arg);
+
+/**
+ * Parser state for pgagroal_parse_message. Zero-initialize before the first
+ * call and pass the same instance on every subsequent call for the same
+ * connection so the parser can resume exactly where the previous read stopped.
+ * All fields are private to the parser; callers must not modify them directly.
+ */
+struct pgagroal_message_state
+{
+   char header[5];          /**< Partial header buffer (kind byte + 4-byte length field) */
+   char first_payload_byte; /**< First byte of the payload, e.g. transaction state for 'Z' */
+   int header_len;          /**< Bytes of the header received so far (0-5); 5 means complete */
+   int payload_remaining;   /**< Payload bytes not yet consumed from the current message */
+};
+
+/**
+ * Read a buffer holding one or more concatenated PostgreSQL protocol messages
+ * that may be split across multiple reads. The caller keeps the parser state
+ * in `state` (zero it before the first call); it is updated so a subsequent
+ * call can continue exactly where this one stopped.
+ *
+ * The callback is invoked once per message. For a message without a payload
+ * it fires as soon as the header (kind byte + length field) is complete; for
+ * a message with a payload it fires when the header and the first payload
+ * byte are present, so the callback can read past the header (e.g. the
+ * transaction state byte of a Z message). A header split across reads is
+ * buffered in the state until it can be parsed, so a split never
+ * desynchronizes the parser.
+ * @param state Parser state, zero-initialized before the first call
+ * @param data The buffer holding the received bytes
+ * @param length The number of received bytes
+ * @param callback The callback to invoke per message
+ * @param arg An argument passed through to the callback
+ */
+void
+pgagroal_parse_message(struct pgagroal_message_state* state,
+                       char* data,
+                       int length,
+                       pgagroal_message_callback callback, void* arg);
+
+/**
+ * Caller-supplied context passed to pgagroal_pipeline_server_rfq via the
+ * pgagroal_parse_message arg parameter. All pointer fields are optional;
+ * pass NULL for any field that does not need tracking.
+ */
+struct pipeline_server_state
+{
+   bool* in_tx;   /**< Updated with the transaction state from 'Z' messages */
+   bool* saw_rfq; /**< Set to true when a genuine idle ReadyForQuery is seen */
+   bool* fatal;   /**< Set to true when an 'E' message carries FATAL or PANIC */
+};
+
+/**
+ * Shared server-side message callback for the session and transaction
+ * pipelines. Updates the pipeline transaction state and prometheus counters
+ * when a genuine ReadyForQuery ('Z') boundary is seen, and sets the fatal
+ * flag when a genuine ErrorResponse ('E') carries FATAL or PANIC.
+ * Safe to call with a NULL arg; returns immediately in that case.
+ * @param kind The message type byte
+ * @param msg Pointer to the message start (kind byte included)
+ * @param msglen Declared total length of the message
+ * @param arg Pointer to a pipeline_server_state, or NULL
+ */
+void
+pgagroal_pipeline_server_rfq(char kind, char* msg, int msglen, void* arg);
+
+/**
  * Write an empty message
  * @param ssl The SSL struct
  * @param socket The socket descriptor

--- a/src/include/worker.h
+++ b/src/include/worker.h
@@ -51,12 +51,14 @@ extern "C" {
  */
 struct worker_io
 {
-   struct io_watcher io; /**< The I/O watcher */
-   int client_fd;        /**< The client descriptor */
-   int server_fd;        /**< The server descriptor */
-   int slot;             /**< The slot */
-   SSL* client_ssl;      /**< The client SSL context */
-   SSL* server_ssl;      /**< The server SSL context */
+   struct io_watcher io;                               /**< The I/O watcher */
+   int client_fd;                                      /**< The client descriptor */
+   int server_fd;                                      /**< The server descriptor */
+   int slot;                                           /**< The slot */
+   SSL* client_ssl;                                    /**< The client SSL context */
+   SSL* server_ssl;                                    /**< The server SSL context */
+   struct pgagroal_message_state client_message_state; /**< The per-connection client parser message state */
+   struct pgagroal_message_state server_message_state; /**< The per-connection server parser message state */
 };
 
 extern volatile int running;

--- a/src/libpgagroal/message.c
+++ b/src/libpgagroal/message.c
@@ -37,6 +37,7 @@
 #include <tls.h>
 #include <utils.h>
 #include <worker.h>
+#include <prometheus.h>
 
 #include <assert.h>
 #include <errno.h>
@@ -389,6 +390,204 @@ pgagroal_free_message(struct message* msg)
 
       free(msg);
       msg = NULL;
+   }
+}
+
+void
+pgagroal_parse_message(struct pgagroal_message_state* state,
+                       char* data,
+                       int length,
+                       pgagroal_message_callback callback,
+                       void* arg)
+{
+   int offset = 0;
+
+   while (offset < length)
+   {
+      /*
+       * Something arrived, so we need to check `state` to understand
+       * where we were.
+       */
+
+      if (state->header_len == 5)
+      {
+         /*
+          * a full header is now present, since it has the length of 5 (kind + length)
+          * therefore get the first byte after the header (e.g., a `I` after a `Z` kind)
+          */
+         state->first_payload_byte = data[offset];
+         offset += 1;
+         state->payload_remaining -= 1;
+         state->header_len = 0; // header read
+
+         if (callback != NULL)
+         {
+            char kind = pgagroal_read_byte(state->header);
+            int msglen = pgagroal_read_int32(state->header + 1) + 1;
+
+            /*
+             * pass the whole thing to the callback, so the kind + length + first byte
+             */
+            char msg[6];
+            memcpy(msg, state->header, 5);
+            msg[5] = state->first_payload_byte;
+            callback(kind, msg, msglen, arg);
+         }
+
+         continue;
+      }
+
+      /*
+       * move forward to consume every other stuff
+       * within the payload
+       */
+      if (state->payload_remaining > 0)
+      {
+         int to_consume = MIN(state->payload_remaining, length - offset);
+         offset += to_consume;
+         state->payload_remaining -= to_consume;
+         continue;
+      }
+
+      /*
+       * here the header has fully arrived and there is nothing
+       * more (no payload)
+       */
+      if (state->header_len == 0 && offset + 5 <= length)
+      {
+         char kind = pgagroal_read_byte(data + offset);
+         int msglen = pgagroal_read_int32(data + offset + 1) + 1;
+
+         if (msglen == 5 || offset + 6 <= length)
+         {
+            /*
+             * payload is present, or the message has none, so the
+             * callback may read past the header (e.g. the Z state byte).
+             */
+            if (callback != NULL)
+            {
+               callback(kind, data + offset, msglen, arg);
+            }
+
+            offset += 5;
+            state->payload_remaining = msglen - 5;
+         }
+         else
+         {
+            /*
+             * header arrived, wait to handle the first payload byte (if any)
+             */
+            memcpy(state->header, data + offset, 5);
+            state->header_len = 5;
+            state->payload_remaining = msglen - 5;
+            offset = length;
+            continue;
+         }
+      }
+      else
+      {
+         /* Buffer a message header split across reads until it is complete */
+         int n = MIN(5 - state->header_len, length - offset);
+         memcpy(state->header + state->header_len, data + offset, n);
+         state->header_len += n;
+         offset += n;
+
+         if (state->header_len < 5)
+         {
+            /* Buffer exhausted mid-header; continue on the next call */
+            continue;
+         }
+
+         char kind = pgagroal_read_byte(state->header);
+         int msglen = pgagroal_read_int32(state->header + 1) + 1;
+
+         state->payload_remaining = msglen - 5;
+
+         if (msglen == 5 || offset < length)
+         {
+            /* The payload is present, or the message has none */
+            state->first_payload_byte = (msglen > 5) ? data[offset] : 0;
+            state->header_len = 0;
+
+            if (callback != NULL)
+            {
+               /* Build a contiguous view so the callback may read msg+5
+                * (e.g. the state byte of a Z message). */
+               char msg[8];
+               memcpy(msg, state->header, 5);
+               msg[5] = state->first_payload_byte;
+               msg[6] = 0;
+               msg[7] = 0;
+               callback(kind, msg, msglen, arg);
+            }
+         }
+         else
+         {
+            /* Await the first payload byte in a later call */
+            state->header_len = 5;
+            continue;
+         }
+      }
+
+      /*
+       * consume any remaining payload
+       */
+      if (state->payload_remaining > 0)
+      {
+         int to_consume = MIN(state->payload_remaining, length - offset);
+         offset += to_consume;
+         state->payload_remaining -= to_consume;
+      }
+   }
+}
+
+void
+pgagroal_pipeline_server_rfq(char kind, char* msg,
+                             int msglen __attribute__((unused)),
+                             void* arg)
+{
+   /*
+    * arg is NULL when the callback is invoked without a caller-supplied
+    * pipeline_server_state (e.g. from a test or a future caller that does
+    * not need saw_rfq or fatal tracking). This is a valid use case for a
+    * general-purpose callback, so return silently rather than crashing.
+    */
+   if (arg == NULL)
+      return;
+
+   struct pipeline_server_state* state = (struct pipeline_server_state*)arg;
+
+   /*
+    * if 'Z' need to read the first payload byte
+    * to get the transaction status
+    */
+   if (kind == 'Z')
+   {
+      char tx_state = pgagroal_read_byte(msg + 5);
+
+      if (tx_state != 'I' && !*(state->in_tx))
+      {
+         pgagroal_prometheus_tx_count_add();
+      }
+
+      *(state->in_tx) = (tx_state != 'I');
+
+      if (state->saw_rfq != NULL && !*(state->in_tx))
+      {
+         *(state->saw_rfq) = true;
+      }
+   }
+   else if (kind == 'E')
+   {
+      if (state->fatal != NULL)
+      {
+         /* msg+6 is valid here because pgagroal_parse_message only fires
+          * the callback once the first payload byte has arrived */
+         if (!strncmp(msg + 6, "FATAL", 5) || !strncmp(msg + 6, "PANIC", 5))
+         {
+            *(state->fatal) = true;
+         }
+      }
    }
 }
 

--- a/src/libpgagroal/pipeline_session.c
+++ b/src/libpgagroal/pipeline_session.c
@@ -60,8 +60,6 @@ static void session_destroy(void*, size_t);
 static void session_periodic(void);
 
 static bool in_tx;
-static int next_client_message;
-static int next_server_message;
 static bool saw_x = false;
 
 #define CLIENT_INIT   0
@@ -140,8 +138,8 @@ session_start(struct event_loop* loop __attribute__((unused)), struct worker_io*
    config = (struct main_configuration*)shmem;
 
    in_tx = false;
-   next_client_message = 0;
-   next_server_message = 0;
+   memset(&w->client_message_state, 0, sizeof(w->client_message_state));
+   memset(&w->server_message_state, 0, sizeof(w->server_message_state));
 
    for (int i = 0; i < config->max_connections; i++)
    {
@@ -283,6 +281,20 @@ session_periodic(void)
 }
 
 static void
+session_client_message(char kind, char* msg __attribute__((unused)), int msglen __attribute__((unused)), void* arg)
+{
+   struct worker_io* wi = (struct worker_io*)arg;
+
+   /* The Q and E message tell us the execute of the simple query and the prepared statement */
+   if (kind == 'Q' || kind == 'E')
+   {
+      pgagroal_prometheus_query_count_add();
+      if (wi != NULL)
+         pgagroal_prometheus_query_count_specified_add(wi->slot);
+   }
+}
+
+static void
 session_client(struct io_watcher* watcher)
 {
    int status = MESSAGE_STATUS_ERROR;
@@ -303,40 +315,11 @@ session_client(struct io_watcher* watcher)
 
       if (likely(msg->kind != 'X'))
       {
-         int offset = 0;
-
-         while (offset < msg->length)
-         {
-            if (next_client_message == 0)
-            {
-               char kind = pgagroal_read_byte(msg->data + offset);
-               int length = pgagroal_read_int32(msg->data + offset + 1);
-
-               /* The Q and E message tell us the execute of the simple query and the prepared statement */
-               if (kind == 'Q' || kind == 'E')
-               {
-                  pgagroal_prometheus_query_count_add();
-                  pgagroal_prometheus_query_count_specified_add(wi->slot);
-               }
-
-               /* Calculate the offset to the next message */
-               if (offset + length + 1 <= msg->length)
-               {
-                  next_client_message = 0;
-                  offset += length + 1;
-               }
-               else
-               {
-                  next_client_message = length + 1 - (msg->length - offset);
-                  offset = msg->length;
-               }
-            }
-            else
-            {
-               offset = MIN(next_client_message, msg->length);
-               next_client_message -= offset;
-            }
-         }
+         pgagroal_parse_message(&wi->client_message_state,
+                                msg->data,
+                                msg->length,
+                                session_client_message,
+                                wi);
 
          status = pgagroal_send_message(watcher, msg);
 
@@ -452,46 +435,12 @@ session_server(struct io_watcher* watcher)
    {
       pgagroal_prometheus_network_received_add(msg->length);
 
-      int offset = 0;
-
-      while (offset < msg->length)
-      {
-         if (next_server_message == 0)
-         {
-            char kind = pgagroal_read_byte(msg->data + offset);
-            int length = pgagroal_read_int32(msg->data + offset + 1);
-
-            /* The Z message tell us the transaction state */
-            if (kind == 'Z')
-            {
-               char tx_state = pgagroal_read_byte(msg->data + offset + 5);
-
-               if (tx_state != 'I' && !in_tx)
-               {
-                  pgagroal_prometheus_tx_count_add();
-               }
-
-               in_tx = tx_state != 'I';
-            }
-
-            /* Calculate the offset to the next message */
-            if (offset + length + 1 <= msg->length)
-            {
-               next_server_message = 0;
-               offset += length + 1;
-            }
-            else
-            {
-               next_server_message = length + 1 - (msg->length - offset);
-               offset = msg->length;
-            }
-         }
-         else
-         {
-            offset = MIN(next_server_message, msg->length);
-            next_server_message -= offset;
-         }
-      }
+      struct pipeline_server_state pipeline_server_state = {&in_tx, NULL, &fatal};
+      pgagroal_parse_message(&wi->server_message_state,
+                             msg->data,
+                             msg->length,
+                             pgagroal_pipeline_server_rfq,
+                             &pipeline_server_state);
 
       status = pgagroal_send_message(watcher, msg);
 
@@ -500,20 +449,10 @@ session_server(struct io_watcher* watcher)
          goto client_error;
       }
 
-      if (unlikely(msg->kind == 'E'))
+      if (fatal)
       {
-         fatal = false;
-
-         if (!strncmp(msg->data + 6, "FATAL", 5) || !strncmp(msg->data + 6, "PANIC", 5))
-         {
-            fatal = true;
-         }
-
-         if (fatal)
-         {
-            exit_code = WORKER_SERVER_FATAL;
-            pgagroal_event_loop_break();
-         }
+         exit_code = WORKER_SERVER_FATAL;
+         pgagroal_event_loop_break();
       }
    }
    else if (status == MESSAGE_STATUS_ZERO)

--- a/src/libpgagroal/pipeline_transaction.c
+++ b/src/libpgagroal/pipeline_transaction.c
@@ -68,8 +68,6 @@ static char username[MAX_USERNAME_LENGTH];
 static char database[MAX_DATABASE_LENGTH];
 static char appname[MAX_APPLICATION_NAME];
 static bool in_tx;
-static int next_client_message;
-static int next_server_message;
 static int unix_socket = -1;
 static int deallocate;
 static bool fatal;
@@ -78,6 +76,7 @@ static bool saw_x = false;
 static struct io_watcher io_mgt;
 static struct worker_io server_io;
 static bool io_watcher_active = false;
+static bool saw_rfq;
 
 struct pipeline
 transaction_pipeline(void)
@@ -109,14 +108,15 @@ transaction_start(struct event_loop* loop, struct worker_io* w)
    struct main_configuration* config = NULL;
 
    config = (struct main_configuration*)shmem;
+   saw_rfq = false;
 
    slot = -1;
    memcpy(&username[0], config->connections[w->slot].username, MAX_USERNAME_LENGTH);
    memcpy(&database[0], config->connections[w->slot].database, MAX_DATABASE_LENGTH);
    memcpy(&appname[0], config->connections[w->slot].appname, MAX_APPLICATION_NAME);
    in_tx = false;
-   next_client_message = 0;
-   next_server_message = 0;
+   memset(&w->client_message_state, 0, sizeof(w->client_message_state));
+   memset(&w->server_message_state, 0, sizeof(w->server_message_state));
    deallocate = false;
 
    memset(&p, 0, sizeof(p));
@@ -199,6 +199,36 @@ transaction_periodic(void)
 }
 
 static void
+transaction_client_message(char kind, char* msg, int msglen __attribute__((unused)), void* arg)
+{
+   struct worker_io* wi = (struct worker_io*)arg;
+   struct main_configuration* config = (struct main_configuration*)shmem;
+
+   if (config->track_prepared_statements)
+   {
+      /* The P message tell us the prepared statement */
+      if (kind == 'P')
+      {
+         char* ps = pgagroal_read_string(msg + 5);
+         if (!pgagroal_compare_string(ps, ""))
+         {
+            deallocate = true;
+         }
+      }
+   }
+
+   /* The Q and E message tell us the execute of the simple query and the prepared statement */
+   if (kind == 'Q' || kind == 'E')
+   {
+      pgagroal_prometheus_query_count_add();
+      if (wi != NULL)
+      {
+         pgagroal_prometheus_query_count_specified_add(wi->slot);
+      }
+   }
+}
+
+static void
 transaction_client(struct io_watcher* watcher)
 {
    int status = MESSAGE_STATUS_ERROR;
@@ -250,53 +280,11 @@ transaction_client(struct io_watcher* watcher)
 
       if (likely(msg->kind != 'X'))
       {
-         int offset = 0;
-
-         while (offset < msg->length)
-         {
-            if (next_client_message == 0)
-            {
-               char kind = pgagroal_read_byte(msg->data + offset);
-               int length = pgagroal_read_int32(msg->data + offset + 1);
-
-               if (config->track_prepared_statements)
-               {
-                  /* The P message tell us the prepared statement */
-                  if (kind == 'P')
-                  {
-                     char* ps = pgagroal_read_string(msg->data + offset + 5);
-                     if (strcmp(ps, ""))
-                     {
-                        deallocate = true;
-                     }
-                  }
-               }
-
-               /* The Q and E message tell us the execute of the simple query and the prepared statement */
-               if (kind == 'Q' || kind == 'E')
-               {
-                  pgagroal_prometheus_query_count_add();
-                  pgagroal_prometheus_query_count_specified_add(wi->slot);
-               }
-
-               /* Calculate the offset to the next message */
-               if (offset + length + 1 <= msg->length)
-               {
-                  next_client_message = 0;
-                  offset += length + 1;
-               }
-               else
-               {
-                  next_client_message = length + 1 - (msg->length - offset);
-                  offset = msg->length;
-               }
-            }
-            else
-            {
-               offset = MIN(next_client_message, msg->length);
-               next_client_message -= offset;
-            }
-         }
+         pgagroal_parse_message(&wi->client_message_state,
+                                msg->data,
+                                msg->length,
+                                transaction_client_message,
+                                wi);
 
          status = pgagroal_send_message(watcher, msg);
 
@@ -413,46 +401,13 @@ transaction_server(struct io_watcher* watcher)
    {
       pgagroal_prometheus_network_received_add(msg->length);
 
-      int offset = 0;
-
-      while (offset < msg->length)
-      {
-         if (next_server_message == 0)
-         {
-            char kind = pgagroal_read_byte(msg->data + offset);
-            int length = pgagroal_read_int32(msg->data + offset + 1);
-
-            /* The Z message tell us the transaction state */
-            if (kind == 'Z')
-            {
-               char tx_state = pgagroal_read_byte(msg->data + offset + 5);
-
-               if (tx_state != 'I' && !in_tx)
-               {
-                  pgagroal_prometheus_tx_count_add();
-               }
-
-               in_tx = tx_state != 'I';
-            }
-
-            /* Calculate the offset to the next message */
-            if (offset + length + 1 <= msg->length)
-            {
-               next_server_message = 0;
-               offset += length + 1;
-            }
-            else
-            {
-               next_server_message = length + 1 - (msg->length - offset);
-               offset = msg->length;
-            }
-         }
-         else
-         {
-            offset = MIN(next_server_message, msg->length);
-            next_server_message -= offset;
-         }
-      }
+      saw_rfq = false; /* reset before each chunk */
+      struct pipeline_server_state pipeline_server_state = {&in_tx, &saw_rfq, &fatal};
+      pgagroal_parse_message(&wi->server_message_state,
+                             msg->data,
+                             msg->length,
+                             pgagroal_pipeline_server_rfq,
+                             &pipeline_server_state);
 
       status = pgagroal_send_message(watcher, msg);
 
@@ -461,16 +416,8 @@ transaction_server(struct io_watcher* watcher)
          goto client_error;
       }
 
-      if (unlikely(msg->kind == 'E'))
-      {
-         if (!strncmp(msg->data + 6, "FATAL", 5) || !strncmp(msg->data + 6, "PANIC", 5))
-         {
-            fatal = true;
-         }
-      }
-
       /* Check for ReadyForQuery message (Z) to detect transaction completion */
-      if (msg->kind == 'Z' && !in_tx && slot != -1)
+      if (saw_rfq && !in_tx && slot != -1)
       {
          /* Transaction completed - stop I/O watcher immediately if still active */
          if (io_watcher_active)

--- a/test/testcases/test_message.c
+++ b/test/testcases/test_message.c
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include <pgagroal.h>
+#include <message.h>
+#include <utils.h>
+#include <mctf.h>
+
+#include <string.h>
+
+/*
+ * Regression tests for the message walker used by the transaction and session
+ * pipelines. A message header (kind byte + int32 length) split across reads
+ * previously desynchronized the parser: the length was read past the end of
+ * the received bytes, the walker skipped a bogus number of payload bytes, and
+ * a 'Z' inside a payload (e.g. the data of "select repeat('Z',4096)") could
+ * be misparsed as a ReadyForQuery. The walker must buffer a split header in
+ * its state until it is complete, and must keep the I/O-stop decision of the
+ * pipelines (a 'Z' at the end of a chunk) working across multiple reads.
+ */
+
+#define D_PAYLOAD_SIZE 4096
+
+/* Collection of messages reported by the walker callback */
+struct walk_result
+{
+   int count;
+   char kinds[64];
+   int z_count;
+   char z_state;
+   int last_msglen;
+};
+
+/* Callback invoked by pgagroal_parse_message for each complete header */
+static void
+walk_cb(char kind, char* msg, int msglen, void* arg)
+{
+   struct walk_result* result = (struct walk_result*)arg;
+
+   if (result->count < (int)sizeof(result->kinds))
+   {
+      result->kinds[result->count] = kind;
+   }
+   result->count++;
+   result->last_msglen = msglen;
+
+   if (kind == 'Z')
+   {
+      result->z_count++;
+      result->z_state = pgagroal_read_byte(msg + 5);
+   }
+}
+
+/* Append one wire message to buffer at offset, returning the new offset */
+static int
+append_message(char* buffer, int offset, char kind, const char* payload, int payload_len)
+{
+   pgagroal_write_byte(buffer + offset, kind);
+   pgagroal_write_int32(buffer + offset + 1, payload_len + 4);
+   if (payload_len > 0)
+   {
+      memcpy(buffer + offset + 5, payload, payload_len);
+   }
+   return offset + 5 + payload_len;
+}
+
+/* Build a server result: DataRow(4096 Z bytes) + CommandComplete + ReadyForQuery */
+static int
+build_server_result(char* buffer)
+{
+   char payload[D_PAYLOAD_SIZE];
+   int offset = 0;
+
+   memset(payload, 'Z', sizeof(payload));
+   offset = append_message(buffer, offset, 'D', payload, sizeof(payload));
+   offset = append_message(buffer, offset, 'C', NULL, 0);
+   offset = append_message(buffer, offset, 'Z', "I", 1);
+
+   return offset;
+}
+
+static bool
+result_ok(int expected_count, const char* expected_kinds, int expected_z_count,
+          struct walk_result* result, char expected_z_state, bool check_z_state)
+{
+   if (result->count != expected_count)
+   {
+      return false;
+   }
+   if (result->count > (int)sizeof(result->kinds))
+   {
+      return false;
+   }
+   result->kinds[expected_count] = '\0';
+   if (strcmp(result->kinds, expected_kinds) != 0)
+   {
+      return false;
+   }
+   if (result->z_count != expected_z_count)
+   {
+      return false;
+   }
+   if (check_z_state && result->z_state != expected_z_state)
+   {
+      return false;
+   }
+   return true;
+}
+
+/* The whole result buffer arrives in a single read. */
+MCTF_TEST(test_message_aligned)
+{
+   char buffer[8192];
+   struct walk_result result;
+   struct pgagroal_message_state state;
+   int length;
+
+   length = build_server_result(buffer);
+   memset(&state, 0, sizeof(state));
+   memset(&result, 0, sizeof(result));
+
+   pgagroal_parse_message(&state, buffer, length, walk_cb, &result);
+
+   MCTF_ASSERT(result_ok(3, "DCZ", 1, &result, 'I', true), cleanup,
+               "aligned walk must report D, C and a single idle Z");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* A message header split across reads at every possible position. */
+MCTF_TEST(test_message_header_split)
+{
+   char buffer[8192];
+   struct walk_result result;
+   struct pgagroal_message_state state;
+   int length;
+   int split;
+
+   length = build_server_result(buffer);
+
+   for (split = 1; split <= 4; split++)
+   {
+      memset(&state, 0, sizeof(state));
+      memset(&result, 0, sizeof(result));
+
+      pgagroal_parse_message(&state, buffer, split, walk_cb, &result);
+      pgagroal_parse_message(&state, buffer + split, length - split, walk_cb, &result);
+
+      MCTF_ASSERT(result_ok(3, "DCZ", 1, &result, 'I', true), cleanup,
+                  "server header split at %d must not desynchronize the walker", split);
+   }
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* A message payload split across reads at every possible position. */
+MCTF_TEST(test_message_payload_split)
+{
+   char buffer[8192];
+   struct walk_result result;
+   struct pgagroal_message_state state;
+   int length;
+   int split;
+
+   length = build_server_result(buffer);
+
+   for (split = 1; split < D_PAYLOAD_SIZE; split++)
+   {
+      memset(&state, 0, sizeof(state));
+      memset(&result, 0, sizeof(result));
+
+      pgagroal_parse_message(&state, buffer, 5 + split, walk_cb, &result);
+      pgagroal_parse_message(&state, buffer + 5 + split, length - (5 + split), walk_cb, &result);
+
+      MCTF_ASSERT(result_ok(3, "DCZ", 1, &result, 'I', true), cleanup,
+                  "payload split at %d must not desynchronize the walker", split);
+   }
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* Every possible split point of the complete result buffer. */
+MCTF_TEST(test_message_exhaustive_splits)
+{
+   char buffer[8192];
+   struct walk_result result;
+   struct pgagroal_message_state state;
+   int length;
+   int split;
+
+   length = build_server_result(buffer);
+
+   for (split = 1; split < length; split++)
+   {
+      memset(&state, 0, sizeof(state));
+      memset(&result, 0, sizeof(result));
+
+      pgagroal_parse_message(&state, buffer, split, walk_cb, &result);
+      pgagroal_parse_message(&state, buffer + split, length - split, walk_cb, &result);
+
+      MCTF_ASSERT(result_ok(3, "DCZ", 1, &result, 'I', true), cleanup,
+                  "split at %d must not desynchronize the walker", split);
+   }
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* A client query split at every possible position. */
+MCTF_TEST(test_message_client_query_split)
+{
+   char buffer[8192];
+   const char* query = "SELECT 1";
+   struct walk_result result;
+   struct pgagroal_message_state state;
+   int length;
+   int split;
+
+   length = append_message(buffer, 0, 'Q', query, (int)strlen(query));
+
+   for (split = 1; split < length; split++)
+   {
+      memset(&state, 0, sizeof(state));
+      memset(&result, 0, sizeof(result));
+
+      pgagroal_parse_message(&state, buffer, split, walk_cb, &result);
+      pgagroal_parse_message(&state, buffer + split, length - split, walk_cb, &result);
+
+      MCTF_ASSERT(result_ok(1, "Q", 0, &result, 0, false), cleanup,
+                  "query split at %d must not desynchronize the walker", split);
+   }
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* A header arriving one byte at a time, then a payload in chunks. */
+MCTF_TEST(test_message_multi_split)
+{
+   char buffer[8192];
+   struct walk_result result;
+   struct pgagroal_message_state state;
+   int length;
+   int i;
+
+   length = build_server_result(buffer);
+   memset(&state, 0, sizeof(state));
+   memset(&result, 0, sizeof(result));
+
+   for (i = 0; i < 5; i++)
+   {
+      pgagroal_parse_message(&state, buffer + i, 1, walk_cb, &result);
+   }
+   for (i = 5; i < length; i += 100)
+   {
+      int n = MIN(100, length - i);
+      pgagroal_parse_message(&state, buffer + i, n, walk_cb, &result);
+   }
+
+   MCTF_ASSERT(result_ok(3, "DCZ", 1, &result, 'I', true), cleanup,
+               "a header split into single bytes must be assembled");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* The Z message split exactly between its length field and its state byte: the
+ * walker must hold the completed header until the state byte arrives so the
+ * callback reports the real transaction state, not a zero. */
+MCTF_TEST(test_message_z_state_split)
+{
+   char buffer[8192];
+   struct walk_result result;
+   struct pgagroal_message_state state;
+   int length;
+
+   length = build_server_result(buffer);
+   memset(&state, 0, sizeof(state));
+   memset(&result, 0, sizeof(result));
+
+   pgagroal_parse_message(&state, buffer, length - 1, walk_cb, &result);
+   pgagroal_parse_message(&state, buffer + length - 1, 1, walk_cb, &result);
+
+   MCTF_ASSERT(result_ok(3, "DCZ", 1, &result, 'I', true), cleanup,
+               "a Z split at 5/1 must report its real state byte");
+
+cleanup:
+   MCTF_FINISH();
+}


### PR DESCRIPTION
Introduces a new structure `postgresql_message_state` that is shared across several continuos invocations of `pgagroal_parse_message` to inspect the header and the content arrived so far.

`pgagroal_parse_message` gets the bytes of an incoming message and look to see if the header is complete or not, and unless the header is complete and a first payload byte has arrived it does nothing but keeping the status of incoming data.
Once the first byte of payload arrives, a callback function is invoked to parse the header and possibly the first byte. `pgagroal_message_state` is used as per-connection client/server parser message state declared in `io_watcher` instead of being global variables.

The critical fix: transaction_server and session_server were using msg->kind (the first byte of the raw TCP chunk) to decide when to return a connection to the pool. A large result whose payload contains 'Z' bytes (e.g. repeat('Z', 2048)) could land a TCP read starting on one of those bytes, making msg->kind == 'Z' while in_tx is false, and triggering a premature connection return mid-stream. The same class of bug affected the 'E'/fatal detection.

Both decisions are now driven by a saw_rfq flag and the fatal flag set inside the callback, which fires only at true protocol message boundaries. The 'E' check is also moved into the callback where msg + 6 is guaranteed safe.

The two per-pipeline server callbacks (transaction_server_message and session_server_message) are merged into a single shared pgagroal_pipeline_server_rfq callback in message.c, alongside pgagroal_parse_message where the callback type is defined.

Close #973