### PR TITLE
Bound the backend query response parsing

### DIFF
--- a/src/libpgagroal/health.c
+++ b/src/libpgagroal/health.c
@@ -295,10 +295,20 @@ server_probe(int server_idx, bool* up, int* auth_type)
       }
 
       offset_q = 0;
-      while (offset_q < msg->length)
+      while (offset_q + 5 <= msg->length)
       {
          type_q = pgagroal_read_byte(msg->data + offset_q);
          len_q = pgagroal_read_int32(msg->data + offset_q + 1);
+
+         /* The length covers itself, so anything below 4 is malformed. It is
+          * also what advances offset_q, so a non-positive value would loop.
+          * Compared by subtraction: offset_q + 1 + len_q would overflow for a
+          * large len_q, and signed overflow is undefined. */
+         if (len_q < 4 || len_q > msg->length - offset_q - 1)
+         {
+            pgagroal_log_debug("Health: invalid message length %d", len_q);
+            goto error;
+         }
 
          if (type_q == 'T' || type_q == 'C' || type_q == 'D')
          {
@@ -315,10 +325,6 @@ server_probe(int server_idx, bool* up, int* auth_type)
          }
 
          offset_q += 1 + len_q;
-         if (offset_q >= msg->length)
-         {
-            break;
-         }
       }
 
       pgagroal_clear_message(msg);

--- a/src/libpgagroal/queries.c
+++ b/src/libpgagroal/queries.c
@@ -90,26 +90,43 @@ pgagroal_read_query_multiple_columns_text(int fd, int expected_cols, char** valu
       }
 
       offset = 0;
-      while (offset < msg->length)
+      while (offset + 5 <= msg->length)
       {
          char kind = pgagroal_read_byte(msg->data + offset);
          int len = pgagroal_read_int32(msg->data + offset + 1);
 
-         if (len <= 0)
+         /* The length covers itself, and is compared by subtraction because
+          * offset + 1 + len would overflow for a large len. */
+         if (len < 4 || len > msg->length - offset - 1)
             goto error;
 
          if (kind == 'D')
          {
+            int dr_end = offset + 1 + len;
             int dr_offset = offset + 5;
-            int num_cols = pgagroal_read_int16(msg->data + dr_offset);
+            int num_cols;
+
+            if (dr_offset + 2 > dr_end)
+               goto error;
+
+            num_cols = pgagroal_read_int16(msg->data + dr_offset);
             dr_offset += 2;
 
             if (num_cols == expected_cols)
             {
                for (int i = 0; i < num_cols; i++)
                {
-                  int col_len = pgagroal_read_int32(msg->data + dr_offset);
+                  int col_len;
+
+                  if (dr_offset + 4 > dr_end)
+                     goto error;
+
+                  col_len = pgagroal_read_int32(msg->data + dr_offset);
                   dr_offset += 4;
+
+                  /* -1 is the protocol's NULL, and carries no data bytes. */
+                  if (col_len < -1 || col_len > dr_end - dr_offset)
+                     goto error;
 
                   if (col_len <= 0)
                   {
@@ -184,26 +201,49 @@ pgagroal_read_query_first_column_text(int fd, char* value, size_t value_size)
       }
 
       offset = 0;
-      while (offset < msg->length)
+      while (offset + 5 <= msg->length)
       {
          char kind = pgagroal_read_byte(msg->data + offset);
          int len = pgagroal_read_int32(msg->data + offset + 1);
 
-         if (len <= 0)
+         /* The length covers itself, and is compared by subtraction because
+          * offset + 1 + len would overflow for a large len. */
+         if (len < 4 || len > msg->length - offset - 1)
          {
             goto error;
          }
 
          if (kind == 'D')
          {
+            int dr_end = offset + 1 + len;
             int dr_offset = offset + 5;
-            int num_cols = pgagroal_read_int16(msg->data + dr_offset);
+            int num_cols;
+
+            if (dr_offset + 2 > dr_end)
+            {
+               goto error;
+            }
+
+            num_cols = pgagroal_read_int16(msg->data + dr_offset);
             dr_offset += 2;
 
             if (num_cols >= 1)
             {
-               int col_len = pgagroal_read_int32(msg->data + dr_offset);
+               int col_len;
+
+               if (dr_offset + 4 > dr_end)
+               {
+                  goto error;
+               }
+
+               col_len = pgagroal_read_int32(msg->data + dr_offset);
                dr_offset += 4;
+
+               /* -1 is the protocol's NULL, and carries no data bytes. */
+               if (col_len < -1 || col_len > dr_end - dr_offset)
+               {
+                  goto error;
+               }
 
                if (col_len == -1)
                {

--- a/src/libpgagroal/server.c
+++ b/src/libpgagroal/server.c
@@ -534,22 +534,53 @@ query_system_identifier(int server_idx, char* identifier, size_t id_size, int* p
       }
 
       offset_q = 0;
-      while (offset_q < msg->length)
+      while (offset_q + 5 <= msg->length)
       {
          char type_q = pgagroal_read_byte(msg->data + offset_q);
          int len_q = pgagroal_read_int32(msg->data + offset_q + 1);
 
+         /* The length covers itself, so anything below 4 is malformed. It is
+          * also what advances offset_q, so a non-positive value would loop.
+          * Compared by subtraction: offset_q + 1 + len_q would overflow for a
+          * large len_q, and signed overflow is undefined. */
+         if (len_q < 4 || len_q > msg->length - offset_q - 1)
+         {
+            pgagroal_log_error("invalid message length %d from server %d", len_q, server_idx);
+            goto error;
+         }
+
          if (type_q == 'D')
          {
             /* DataRow: 'D' | int32 len | int16 num_cols | int32 col_len | data */
+            int dr_end = offset_q + 1 + len_q;
             int dr_offset = offset_q + 5; /* skip 'D' + len */
-            int num_cols = pgagroal_read_int16(msg->data + dr_offset);
+            int num_cols;
+
+            if (dr_offset + 2 > dr_end)
+            {
+               goto error;
+            }
+
+            num_cols = pgagroal_read_int16(msg->data + dr_offset);
             dr_offset += 2;
 
             if (num_cols >= 1)
             {
-               int col_len = pgagroal_read_int32(msg->data + dr_offset);
+               int col_len;
+
+               if (dr_offset + 4 > dr_end)
+               {
+                  goto error;
+               }
+
+               col_len = pgagroal_read_int32(msg->data + dr_offset);
                dr_offset += 4;
+
+               /* -1 is the protocol's NULL, and carries no data bytes. */
+               if (col_len < -1 || col_len > dr_end - dr_offset)
+               {
+                  goto error;
+               }
 
                if (col_len > 0 && (size_t)col_len < id_size)
                {
@@ -566,8 +597,20 @@ query_system_identifier(int server_idx, char* identifier, size_t id_size, int* p
             /* Parse 'server_version_num' (second column) */
             if (num_cols >= 2 && pg_version != NULL)
             {
-               int col_len2 = pgagroal_read_int32(msg->data + dr_offset);
+               int col_len2;
+
+               if (dr_offset + 4 > dr_end)
+               {
+                  goto error;
+               }
+
+               col_len2 = pgagroal_read_int32(msg->data + dr_offset);
                dr_offset += 4;
+
+               if (col_len2 < -1 || col_len2 > dr_end - dr_offset)
+               {
+                  goto error;
+               }
 
                if (col_len2 > 0)
                {
@@ -595,10 +638,6 @@ query_system_identifier(int server_idx, char* identifier, size_t id_size, int* p
          }
 
          offset_q += 1 + len_q;
-         if (offset_q >= msg->length)
-         {
-            break;
-         }
       }
 
       pgagroal_clear_message(msg);


### PR DESCRIPTION
Fixes #1016.

Both loops that parse the backend's query response — `query_system_identifier()` in `server.c` and `server_probe()` in `health.c` — take the message length field off the wire and use it unchecked.

A length of -1 makes `offset_q += 1 + len_q` leave the offset where it was, so the loop never ends. And in `query_system_identifier()` the DataRow column length is checked against `id_size`, the destination, but never against how many bytes of the message remain, so a short row copies stale bytes from the previous response into the identifier. Since that identifier is what decides whether two servers are the same cluster, a wrong value there is worse than a crash.

The change validates the header before reading it, rejects a length below 4 or one that runs past the message, and bounds `num_cols` and both column lengths against the end of the DataRow. `pipeline_session.c` and `pipeline_transaction.c` already guard their loops this way with `if (offset + length + 1 <= msg->length)`.

The `if (offset_q >= msg->length) break;` at the bottom of both loops is now redundant — the loop condition covers it — so it is gone.

## Verification

I could not configure a build here, so I pulled both loops into a standalone harness and ran the old and new versions side by side over crafted messages:

```
well-formed DataRow (both must parse it identically)
   OLD: returned after 1 iterations, identifier="7291076872994594816"
   NEW: returned after 1 iterations, identifier="7291076872994594816"

length field of -1
   OLD: STILL LOOPING (cut off at 1,000,000)
   NEW: rejected the message (goto error) after 1 iterations

DataRow claims a 40-byte column but only 4 bytes are present
   OLD: reads 36 bytes past the valid message
   OLD: identifier="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
   NEW: rejected the message (goto error) after 1 iterations
```

The first case is the one that matters for regressions: a valid response parses to the same identifier before and after.

`clang -fsyntax-only -I src/include` is clean on both files, and `clang-format` reports no changes — I checked both files are format-clean on `master` first.

I have not driven a real PostgreSQL server into sending a malformed response, so the reachability argument is from reading the parse loop, not from a live server.
