### PR TITLE
doc: Add Ubuntu/Debian build dependencies to DISTRIBUTIONS.md

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,3 +42,4 @@ youssef-joe <joe92228@gmail.com>
 Mohammad El-Shennawy <mohamedwork216@gmail.com>
 Finn Rayk Gartner <finn.gartner@canonical.com>
 R Sai Pranav <rajasaipranav0@gmail.com>
+Esraa Yehia <yehiae996@gmail.com>

--- a/doc/DISTRIBUTIONS.md
+++ b/doc/DISTRIBUTIONS.md
@@ -61,3 +61,21 @@ pkg install cmake          	\
             texlive-formats \
             binutils
 ```
+
+## Compiling on Ubuntu / Debian
+
+All the dependencies can be installed via `apt(8)` as follows:
+
+```sh
+apt install git gcc cmake make \
+            libssl-dev liburing-dev \
+            systemd libsystemd-dev \
+            python3-docutils \
+            libatomic1 \
+            zlib1g-dev \
+            libzstd-dev \
+            liblz4-dev \
+            libbz2-dev \
+            binutils \
+            clang clang-tools
+```

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -50,6 +50,7 @@ youssef-joe <joe92228@gmail.com>
 Mohammad El-Shennawy <mohamedwork216@gmail.com>
 Finn Rayk Gartner <finn.gartner@canonical.com>
 R Sai Pranav <rajasaipranav0@gmail.com>
+Esraa Yehia <yehiae996@gmail.com>
 ```
 
 ## Committers


### PR DESCRIPTION
Closes #1019

### Summary of Changes
- Added a dedicated "Compiling on Ubuntu / Debian" section to `doc/DISTRIBUTIONS.md` using `apt(8)`.
- Documented all required development headers and runtime dependencies for Ubuntu/Debian environments.

### Verification
- Verified package availability via `apt --dry-run`.
- Performed a clean rebuild (`cmake` and `make`) on Ubuntu 24.04, reaching 100% build completion successfully without missing dependencies.