### PR TITLE
[#1022] Remove lingering libev dependencies and fix code and documentation typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,6 @@ jobs:
             pkg install -y \
               bash \
               sudo \
-              libev \
               cmake \
               postgresql17-server \
               postgresql17-contrib \

--- a/contrib/docker/Dockerfile.alpine
+++ b/contrib/docker/Dockerfile.alpine
@@ -43,7 +43,6 @@ RUN apk add --no-cache \
     libpq \
     libpq-dev \
     musl-dev \
-    libev-dev \
     py-docutils \
     doxygen graphviz \
     libatomic \

--- a/contrib/docker/Dockerfile.rocky10
+++ b/contrib/docker/Dockerfile.rocky10
@@ -46,7 +46,6 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch
         bzip2-devel \
         libpq \
         libpq-devel \
-        libev-devel \
         python3-docutils \
         doxygen \
         openssl-devel \

--- a/doc/DISTRIBUTIONS.md
+++ b/doc/DISTRIBUTIONS.md
@@ -5,7 +5,7 @@
 * a C compiler like [gcc 8+](https://gcc.gnu.org) (C17) or [clang 8+](https://clang.llvm.org/)
 * [cmake](https://cmake.org)
 * [GNU make](https://www.gnu.org/software/make/) or BSD `make`
-* [libev](http://software.schmorp.de/pkg/libev.html)
+* [liburing](https://github.com/axboe/liburing) (on Linux)
 * [OpenSSL 3.0+](http://www.openssl.org/)
 * [rst2man](https://docutils.sourceforge.io/)
 * [libatomic](https://gcc.gnu.org/wiki/Atomic)
@@ -27,7 +27,7 @@ All the dependencies can be installed via `dnf(8)` as follows:
 
 ```sh
 dnf install git gcc cmake make    \
-            libev libev-devel     \
+            liburing liburing-devel \
             openssl openssl-devel \
             systemd systemd-devel \
             python3-docutils      \
@@ -53,7 +53,6 @@ All the dependencies can be installed via `pkg(8)` as follows:
 
 ```sh
 pkg install cmake          	\
-            libev libevent 	\
             py311-docutils 	\
             lzlib           \
             liblz4          \

--- a/doc/manual/en/79-distributions.md
+++ b/doc/manual/en/79-distributions.md
@@ -11,7 +11,7 @@ This chapter provides installation instructions for different operating systems 
 * a C compiler like [gcc 8+][gcc] (C17) or [clang 8+][clang]
 * [cmake][cmake]
 * [GNU make][make] or BSD `make`
-* [libev][libev]
+* [liburing][liburing] (on Linux)
 * [OpenSSL 3.0+][openssl]
 * [rst2man][rst2man]
 * [libatomic](https://gcc.gnu.org/wiki/Atomic)
@@ -31,7 +31,7 @@ All the dependencies can be installed via `dnf(8)` as follows:
 
 ```sh
 dnf install git gcc cmake make    \
-            libev libev-devel     \
+            liburing liburing-devel \
             openssl openssl-devel \
             systemd systemd-devel \
             python3-docutils      \
@@ -57,7 +57,6 @@ All the dependencies can be installed via `pkg(8)` as follows:
 
 ```sh
 pkg install cmake          	\
-            libev libevent 	\
             py311-docutils 	\
             lzlib           \
             liblz4          \
@@ -80,7 +79,7 @@ For Ubuntu and Debian systems:
 
 ```sh
 apt-get update
-apt-get install build-essential cmake libev-dev libssl-dev libsystemd-dev python3-docutils libatomic1 zlib1g-dev libzstd-dev liblz4-dev libbz2-dev binutils
+apt-get install build-essential cmake liburing-dev libssl-dev libsystemd-dev python3-docutils libatomic1 zlib1g-dev libzstd-dev liblz4-dev libbz2-dev binutils
 ```
 
 ### macOS

--- a/doc/manual/en/99-references.md
+++ b/doc/manual/en/99-references.md
@@ -18,6 +18,7 @@ This section contains reference links used throughout the manual.
 - **CMake**: https://cmake.org
 - **Make**: https://www.gnu.org/software/make/
 - **libev**: http://software.schmorp.de/pkg/libev.html
+- **liburing**: https://github.com/axboe/liburing
 - **OpenSSL**: http://www.openssl.org/
 - **systemd**: https://www.freedesktop.org/wiki/Software/systemd/
 - **rst2man**: https://docutils.sourceforge.io/
@@ -107,6 +108,7 @@ This section contains reference links used throughout the manual.
   [cmake]: https://cmake.org
   [make]: https://www.gnu.org/software/make/
   [libev]: http://software.schmorp.de/pkg/libev.html
+  [liburing]: https://github.com/axboe/liburing
   [openssl]: http://www.openssl.org/
   [systemd]: https://www.freedesktop.org/wiki/Software/systemd/
   [rst2man]: https://docutils.sourceforge.io/
@@ -136,7 +138,7 @@ This section contains reference links used throughout the manual.
 <!-- src/include -->
 [shmem_h]: https://github.com/pgagroal/pgagroal/blob/master/src/include/shmem.h
 [pgagroal_h]: https://github.com/pgagroal/pgagroal/blob/master/src/include/pgagroal.h
-[messge_h]: https://github.com/pgagroal/pgagroal/blob/master/src/include/message.h
+[message_h]: https://github.com/pgagroal/pgagroal/blob/master/src/include/message.h
 [network_h]: https://github.com/pgagroal/pgagroal/blob/master/src/include/network.h
 [memory_h]: https://github.com/pgagroal/pgagroal/blob/master/src/include/memory.h
 [management_h]: https://github.com/pgagroal/pgagroal/blob/master/src/include/management.h

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -451,7 +451,7 @@ pgagroal_init_pidfile_if_needed(void);
  * take into account doing a prefill. For example, there must
  * be users and limits set, otherwise it does not
  * make any sense to attempt a prefill.
- * This can be used to wrap the condituion before calling
+ * This can be used to wrap the condition before calling
  * other prefill functions, e.g., `pgagroal_prefill()`.
  */
 bool
@@ -467,7 +467,7 @@ pgagroal_can_prefill(void);
  * it can be written as 'section.context.search'.
  * If both the section and the context are omitted, the 'search' is performed among the
  * pgagroal global settings (i.e., those under the [pgagroal] main section). The same
- * happens if the the section is specified as 'pgagroal', therefore the following two
+ * happens if the section is specified as 'pgagroal', therefore the following two
  * terms do the same search:
  * - `update_process_title`
  * - `pgagroal.update_process_title`
@@ -481,16 +481,16 @@ pgagroal_can_prefill(void);
  * by means of 'context', and within such the 'search' is performed.
  *
  * In the case of the `server` section, the `context` has to be the name of a server configured,
- * while the `search` has to be the keyword to look for. AS an example: `server.venkman.port` provides
+ * while the `search` has to be the keyword to look for. As an example: `server.venkman.port` provides
  * the value of the 'port' setting under the server section '[venkman]'.
  *
- * In the case of the 'hba` section, the `context` has to be a username as it appears in a line
+ * In the case of the `hba` section, the `context` has to be a username as it appears in a line
  * of the pgagroal_hba.conf file, while the `search` has to be the column keyword to snoop.
  * For example, `hba.luca.method` will seek for the `method` used to authenticate the user `luca`.
  * Please note that, since the same user could be listed more than once, only the first matching
  * entry is reported.
  *
- * In the case of the 'limit` section, the `context` has to be a database name as it appears in a line
+ * In the case of the `limit` section, the `context` has to be a database name as it appears in a line
  * of the pgagroal_database.conf file, while the `search` has to be the column keyword to snoop.
  * For example, `limit.pgbench.max_size` will seek for the `max_size` connection limit for the
  * database 'pgbench'.

--- a/src/include/prometheus.h
+++ b/src/include/prometheus.h
@@ -175,8 +175,8 @@ void
 pgagroal_prometheus_connection_awaiting(int limit_index);
 
 /**
- * An awaiting connection, i.e., one holded by `blocking_timeout`
- * that is no more on hold and can restart its workflo.
+ * An awaiting connection, i.e., one held by `blocking_timeout`
+ * that is no longer on hold and can restart its workflow.
  *
  *
  * <b>
@@ -350,7 +350,7 @@ pgagroal_prometheus_logging(int logging);
  * even if the cache has not been configured at all!
  *
  * If the memory cannot be allocated, the function issues errors
- * in the logs and disables the caching machinaery.
+ * in the logs and disables the caching machinery.
  *
  * @param p_size a pointer to where to store the size of
  * allocated chunk of memory

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -1292,7 +1292,7 @@ pgagroal_prefill(bool initial)
 
       if (size > 0)
       {
-         // do not perform prefil if
+         // do not perform prefill if
          // - the database is a reserved word
          // - the username is reserved
          if (pgagroal_is_database_reserved(config->limits[i].database) || pgagroal_is_username_reserved(config->limits[i].username))

--- a/src/libpgagroal/server.c
+++ b/src/libpgagroal/server.c
@@ -929,7 +929,7 @@ pgagroal_update_server_state(int slot, int socket, SSL* ssl)
 
    if (process_server_parameters(server, server_parameters))
    {
-      pgagroal_log_trace("uanble to process server_parameters for %s", config->servers[server].name);
+      pgagroal_log_trace("unable to process server_parameters for %s", config->servers[server].name);
       goto error;
    }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1611,7 +1611,7 @@ accept_main_cb(struct io_watcher* watcher)
        * children processes to be independent. */
       if (setpgid(0, 0) == -1)
       {
-         pgagroal_log_error("setpgid error: %s", __func__, strerror(errno));
+         pgagroal_log_error("%s: setpgid error: %s", __func__, strerror(errno));
          exit(1);
       }
 

--- a/test/check.sh
+++ b/test/check.sh
@@ -1277,7 +1277,7 @@ if [[ -n "$SUBCOMMAND" ]]; then
     $SUDO dnf install -y \
       cmake \
       make \
-      libev libev-devel \
+      liburing liburing-devel \
       openssl openssl-devel \
       systemd systemd-devel \
       zlib zlib-devel \


### PR DESCRIPTION
- Remove obsolete external libev package references from CI workflows, Dockerfiles, setup script, and distribution documentation in favor of liburing / kqueue.
- Retain libev reference in 99-references.md to support historical benchmarking documentation.
- Fix logging format string specifier mismatch in main.c setpgid error handling.
- Fix typos and grammatical issues in server.c, pool.c, configuration.h, prometheus.h, and 99-references.md.