### PR TITLE
Add corner-case tests for the numeric append helpers

### DIFF
--- a/test/testcases/test_utils.c
+++ b/test/testcases/test_utils.c
@@ -30,6 +30,7 @@
 #include <mctf.h>
 #include <utils.h>
 
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -103,5 +104,45 @@ MCTF_TEST(test_utils_compare_string)
                "different strings should not compare equal");
 
 cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_utils_append_numbers)
+{
+   char* s = NULL;
+
+   /* The largest value of each type is the corner case: it needs every digit
+      the buffer can hold, so a size argument that is one short truncates it
+      silently rather than overflowing. */
+   s = pgagroal_append_int(NULL, INT_MIN);
+   MCTF_ASSERT_PTR_NONNULL(s, cleanup, "append_int returned NULL");
+   MCTF_ASSERT_STR_EQ(s, "-2147483648", cleanup, "append_int truncated INT_MIN");
+   free(s);
+   s = NULL;
+
+   s = pgagroal_append_int(NULL, INT_MAX);
+   MCTF_ASSERT_STR_EQ(s, "2147483647", cleanup, "append_int wrong for INT_MAX");
+   free(s);
+   s = NULL;
+
+   s = pgagroal_append_ulong(NULL, ULONG_MAX);
+   MCTF_ASSERT_PTR_NONNULL(s, cleanup, "append_ulong returned NULL");
+   MCTF_ASSERT_STR_EQ(s, "18446744073709551615", cleanup, "append_ulong truncated ULONG_MAX");
+   free(s);
+   s = NULL;
+
+   s = pgagroal_append_ullong(NULL, ULLONG_MAX);
+   MCTF_ASSERT_PTR_NONNULL(s, cleanup, "append_ullong returned NULL");
+   MCTF_ASSERT_STR_EQ(s, "18446744073709551615", cleanup, "append_ullong truncated ULLONG_MAX");
+   free(s);
+   s = NULL;
+
+   /* Appending onto an existing string must concatenate, not replace */
+   s = pgagroal_append(NULL, "n=");
+   s = pgagroal_append_ulong(s, ULONG_MAX);
+   MCTF_ASSERT_STR_EQ(s, "n=18446744073709551615", cleanup, "append_ulong did not concatenate");
+
+cleanup:
+   free(s);
    MCTF_FINISH();
 }


### PR DESCRIPTION
Fixes #1029.

Adds `test_utils_append_numbers`, covering `pgagroal_append_int()`, `pgagroal_append_ulong()` and `pgagroal_append_ullong()` at the corner case the truncation fixed in #1028 lived at: the largest value of each type, where the buffer needs every digit it can hold.

These helpers had no assertions anywhere in the suite, which is why the truncation went unnoticed.

This is the test half of #1028. I pushed it to that branch a few minutes after you merged, so it was never part of the merge — sorry for the confusion that caused. It is here as its own change against current `master`.

## Verification

The red-before-green proof was done in pgmoneta, where the suite runs without a live PostgreSQL (pgmoneta/pgmoneta#1282). Same helpers, same tests:

```
                            before the fix   after
test_utils_append_numbers        FAIL         PASS    "append_int truncated INT_MIN"
```

Here the tests compile against current `master` and `clang-format` reports no changes, but I could not run them: `pgagroal_test` wants `<dir> <user> <db>` and a live PostgreSQL, and prints nothing without one. CI is the real check.
