### PR TITLE
Remove redundant memory initialization from reset query

### DIFF
--- a/src/libpgagroal/message.c
+++ b/src/libpgagroal/message.c
@@ -765,10 +765,6 @@ pgagroal_write_reset_query(SSL* ssl, int socket)
       goto error;
    }
 
-   /* XXX: someone is destroying the memory before reaching here in the worker.
-    * Allocate another buffer for now, but this needs fixing. */
-   pgagroal_memory_init();
-
    if (ssl == NULL)
    {
       status = read_message(socket, true, 0, &reply);


### PR DESCRIPTION
## Description

`pgagroal_write_reset_query()` currently calls `pgagroal_memory_init()` immediately before reading the server response.

Both `read_message()` and `ssl_read_message()` already initialize the reusable memory internally before reading a message, making this additional initialization redundant.

### Investigation

As part of investigating #1020, I traced the history of this initialization and the surrounding worker and authentication paths.

The `pgagroal_memory_init()` call was not introduced with `pgagroal_write_reset_query()`. It was inherited from the older `pgagroal_write_discard_all()` implementation.

Git history shows that the initialization and the following comment were introduced with the custom event-loop changes in commit `d981313c`:

> XXX: someone is destroying the memory before reaching here in the worker. Allocate another buffer for now, but this needs fixing.

The same workaround remained in `pgagroal_write_discard_all()` and was later carried over when the function was generalized to `pgagroal_write_reset_query()` in commit `dee3afb`.

I also traced the current worker and authentication flow. The current `pgagroal_authenticate()` worker path does not show a `pgagroal_memory_destroy()` call that would explain the comment. In addition, both message-reading functions already perform their own memory initialization.

Based on this investigation, the old workaround is no longer necessary and can be removed without changing the worker's memory ownership or lifetime.

### Changes

* Removed the obsolete `XXX` comment.
* Removed the redundant `pgagroal_memory_init()` call from `pgagroal_write_reset_query()`.
* No other functional changes were made.

### Testing

Ran the full test suite with:

`./test/check.sh`

Result:

* 143 tests total
* 142 passed
* 0 failed
* 1 skipped

The skipped test requires the metrics endpoint to be enabled.

### Related Issue

Related to #1020
