### PR TITLE
Build the alias column with the append helpers

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -55,7 +55,6 @@
 #include <openssl/ssl.h>
 
 #define HELP                   99
-#define DB_ALIAS_STRING_LENGTH 512
 
 #define COMMAND_CANCELSHUTDOWN "cancel-shutdown"
 #define COMMAND_CLEAR          "clear"
@@ -1965,8 +1964,9 @@ process_alias_result(SSL* ssl, int socket, int32_t output_format)
          }
 
          // Build the database=aliases string
-         char db_alias_string[DB_ALIAS_STRING_LENGTH];
-         pgagroal_snprintf(db_alias_string, sizeof(db_alias_string), "%s", database);
+         char* db_alias_string = NULL;
+
+         db_alias_string = pgagroal_append(db_alias_string, database);
 
          struct json* alias_list = (struct json*)pgagroal_json_get(entry, CONFIGURATION_ARGUMENT_LIMIT_ALIASES);
 
@@ -1979,7 +1979,7 @@ process_alias_result(SSL* ssl, int socket, int32_t output_format)
                {
                   if (first)
                   {
-                     strcat(db_alias_string, "=");
+                     db_alias_string = pgagroal_append_char(db_alias_string, '=');
                   }
 
                   // Aliases are simple strings
@@ -1989,15 +1989,16 @@ process_alias_result(SSL* ssl, int socket, int32_t output_format)
                   {
                      pgagroal_log_debug("Error: Corrupted alias data - missing alias field");
                      pgagroal_json_iterator_destroy(alias_iter);
+                     free(db_alias_string);
                      result = 1;
                      goto cleanup;
                   }
 
                   if (!first)
                   {
-                     strcat(db_alias_string, ",");
+                     db_alias_string = pgagroal_append_char(db_alias_string, ',');
                   }
-                  strcat(db_alias_string, alias);
+                  db_alias_string = pgagroal_append(db_alias_string, alias);
                   first = false;
                }
                pgagroal_json_iterator_destroy(alias_iter);
@@ -2017,6 +2018,9 @@ process_alias_result(SSL* ssl, int socket, int32_t output_format)
             // If no limit data, just show database=aliases and username
             printf("%-40s %-10s\n", db_alias_string, username);
          }
+
+         free(db_alias_string);
+         db_alias_string = NULL;
       }
    }
    else


### PR DESCRIPTION
Fixes #1035.

`list_limits` built the `database=alias,alias,...` column with `strcat` into a 512-byte stack buffer, with nothing bounding the loop. The configuration allows up to 8 aliases of 256 characters plus a 256-character database name, so the worst case it permits is 2304 bytes — an overflow of 1792.

It does not take the worst case. A 30-character database with 8 aliases of 60 characters is 519 bytes and already overruns it, so this is reachable from an ordinary configuration.

This uses `pgagroal_append()` and `pgagroal_append_char()` instead, which is the direction @jesperpedersen asked for in this area: the allocation grows as it goes, so there is no buffer to overrun, and `DB_ALIAS_STRING_LENGTH` is no longer needed.

The string is freed after it is printed, and on the corrupted-alias error path.

## Verification

`clang-format` reports no changes and the project builds clean. `strcat` no longer appears in `cli.c`.

I could not run the suite: `pgagroal_test` wants `<dir> <user> <db>` and a live PostgreSQL, and prints nothing without one. The overflow arithmetic above is from the configuration limits in `pgagroal.h`, not from triggering it.
