### PR TITLE
[#1015] Use pgagroal_strcmp and pgagroal_strcasecmp

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -689,7 +689,7 @@ username:
    while (fgets(line, sizeof(line), users_file))
    {
       ptr = strtok(line, ":");
-      if (!strcmp(username, ptr))
+      if (pgagroal_strcmp(username, ptr))
       {
          warnx("Existing user: %s", username);
          goto error;
@@ -1038,7 +1038,7 @@ username:
       memcpy(&line_copy, &line, strlen(line));
 
       ptr = strtok(line, ":");
-      if (!strcmp(username, ptr))
+      if (pgagroal_strcmp(username, ptr))
       {
          /* Password */
          if (password == NULL)
@@ -1369,7 +1369,7 @@ username:
       memcpy(&line_copy, &line, strlen(line));
 
       ptr = strtok(line, ":");
-      if (!strcmp(username, ptr))
+      if (pgagroal_strcmp(username, ptr))
       {
          found = true;
       }

--- a/src/cli.c
+++ b/src/cli.c
@@ -524,19 +524,19 @@ main(int argc, char** argv)
             }
             break;
          case 'E':
-            if (!strcmp(optarg, "aes") || !strcmp(optarg, "aes256") || !strcmp(optarg, "aes256gcm"))
+            if (pgagroal_strcmp(optarg, "aes") || pgagroal_strcmp(optarg, "aes256") || pgagroal_strcmp(optarg, "aes256gcm"))
             {
                encryption = MANAGEMENT_ENCRYPTION_AES256_GCM;
             }
-            else if (!strcmp(optarg, "aes192") || !strcmp(optarg, "aes192gcm"))
+            else if (pgagroal_strcmp(optarg, "aes192") || pgagroal_strcmp(optarg, "aes192gcm"))
             {
                encryption = MANAGEMENT_ENCRYPTION_AES192_GCM;
             }
-            else if (!strcmp(optarg, "aes128") || !strcmp(optarg, "aes128gcm"))
+            else if (pgagroal_strcmp(optarg, "aes128") || pgagroal_strcmp(optarg, "aes128gcm"))
             {
                encryption = MANAGEMENT_ENCRYPTION_AES128_GCM;
             }
-            else if (!strcmp(optarg, "none"))
+            else if (pgagroal_strcmp(optarg, "none"))
             {
                encryption = MANAGEMENT_ENCRYPTION_NONE;
                break;
@@ -985,48 +985,48 @@ help_switch_to(void)
 static void
 display_helper(char* command)
 {
-   if (!strcmp(command, COMMAND_CANCELSHUTDOWN))
+   if (pgagroal_strcmp(command, COMMAND_CANCELSHUTDOWN))
    {
       help_cancel_shutdown();
    }
-   else if (!strcmp(command, COMMAND_CONFIG_GET) ||
-            !strcmp(command, COMMAND_CONFIG_LS) ||
-            !strcmp(command, COMMAND_CONFIG_SET) ||
-            !strcmp(command, COMMAND_CONFIG_ALIAS) ||
-            !strcmp(command, COMMAND_RELOAD))
+   else if (pgagroal_strcmp(command, COMMAND_CONFIG_GET) ||
+            pgagroal_strcmp(command, COMMAND_CONFIG_LS) ||
+            pgagroal_strcmp(command, COMMAND_CONFIG_SET) ||
+            pgagroal_strcmp(command, COMMAND_CONFIG_ALIAS) ||
+            pgagroal_strcmp(command, COMMAND_RELOAD))
    {
       help_conf();
    }
-   else if (!strcmp(command, COMMAND_DISABLEDB))
+   else if (pgagroal_strcmp(command, COMMAND_DISABLEDB))
    {
       help_disabledb();
    }
-   else if (!strcmp(command, COMMAND_ENABLEDB))
+   else if (pgagroal_strcmp(command, COMMAND_ENABLEDB))
    {
       help_enabledb();
    }
-   else if (!strcmp(command, COMMAND_FLUSH))
+   else if (pgagroal_strcmp(command, COMMAND_FLUSH))
    {
       help_flush();
    }
-   else if (!strcmp(command, COMMAND_PING))
+   else if (pgagroal_strcmp(command, COMMAND_PING))
    {
       help_ping();
    }
-   else if (!strcmp(command, COMMAND_CLEAR) ||
-            !strcmp(command, COMMAND_CLEAR_SERVER))
+   else if (pgagroal_strcmp(command, COMMAND_CLEAR) ||
+            pgagroal_strcmp(command, COMMAND_CLEAR_SERVER))
    {
       help_clear();
    }
-   else if (!strcmp(command, COMMAND_SHUTDOWN))
+   else if (pgagroal_strcmp(command, COMMAND_SHUTDOWN))
    {
       help_shutdown();
    }
-   else if (!strcmp(command, COMMAND_STATUS))
+   else if (pgagroal_strcmp(command, COMMAND_STATUS))
    {
       help_status_details();
    }
-   else if (!strcmp(command, COMMAND_SWITCH_TO))
+   else if (pgagroal_strcmp(command, COMMAND_SWITCH_TO))
    {
       help_switch_to();
    }
@@ -1559,7 +1559,7 @@ process_set_result(SSL* ssl, int socket, char* config_key, int32_t output_format
    }
 
    // Handle success cases with accurate messaging
-   if (conf_status && !strcmp(conf_status, CONFIGURATION_STATUS_SUCCESS))
+   if (conf_status && pgagroal_strcmp(conf_status, CONFIGURATION_STATUS_SUCCESS))
    {
       printf("Configuration change applied successfully\n");
       printf("   Parameter: %s\n", config_key ? config_key : "unknown");
@@ -1567,7 +1567,7 @@ process_set_result(SSL* ssl, int socket, char* config_key, int32_t output_format
       printf("   New value: %s\n", new_value ? new_value : "unknown");
       printf("   Status: Active (applied to running instance)\n");
    }
-   else if (conf_status && !strcmp(conf_status, CONFIGURATION_STATUS_RESTART_REQUIRED))
+   else if (conf_status && pgagroal_strcmp(conf_status, CONFIGURATION_STATUS_RESTART_REQUIRED))
    {
       printf("Configuration change requires manual restart\n");
       printf("   Parameter: %s\n", config_key ? config_key : "unknown");
@@ -1689,7 +1689,7 @@ get_config_key_result(char* config_key, struct json* j, uintptr_t* r, int32_t ou
       key[MISC_LENGTH - 1] = '\0';
 
       // Treat "pgagroal" as the main section (empty)
-      if (!strcasecmp(section, "pgagroal"))
+      if (pgagroal_strcasecmp(section, "pgagroal"))
       {
          memset(section, 0, MISC_LENGTH);
       }
@@ -1751,14 +1751,14 @@ get_config_key_result(char* config_key, struct json* j, uintptr_t* r, int32_t ou
       if (strlen(context) > 0)
       {
          // Looking for a specific context (like "mydb" in "limit.mydb.username")
-         if (!strcmp(context, iter->key) && iter->value->type == ValueJSON)
+         if (pgagroal_strcmp(context, iter->key) && iter->value->type == ValueJSON)
          {
             struct json* nested_obj = (struct json*)iter->value->data;
             struct json_iterator* nested_iter;
             pgagroal_json_iterator_create(nested_obj, &nested_iter);
             while (pgagroal_json_iterator_next(nested_iter))
             {
-               if (!strcmp(key, nested_iter->key))
+               if (pgagroal_strcmp(key, nested_iter->key))
                {
                   config_value = pgagroal_value_to_string(nested_iter->value, FORMAT_TEXT, NULL, 0);
                   if (output_format == MANAGEMENT_OUTPUT_FORMAT_JSON)
@@ -1772,7 +1772,7 @@ get_config_key_result(char* config_key, struct json* j, uintptr_t* r, int32_t ou
             break;
          }
       }
-      else if (!strcmp(key, iter->key))
+      else if (pgagroal_strcmp(key, iter->key))
       {
          // Handle single or two-part keys
          if (iter->value->type == ValueJSON)

--- a/src/config.c
+++ b/src/config.c
@@ -540,7 +540,7 @@ config_init(const char* output_path, bool quiet, bool force)
       {
          if (prompt_input("Log level (fatal, error, warn, info, debug, trace)", CONFIGURATION_DEFAULT_LOG_LEVEL, log_level, sizeof(log_level)) == 0)
          {
-            if (pgagroal_as_logging_level(log_level) != PGAGROAL_LOGGING_LEVEL_FATAL || !strcasecmp(log_level, "fatal"))
+            if (pgagroal_as_logging_level(log_level) != PGAGROAL_LOGGING_LEVEL_FATAL || pgagroal_strcasecmp(log_level, "fatal"))
             {
                break;
             }
@@ -750,7 +750,7 @@ config_get(const char* file_path, const char* section, const char* key)
             *(bracket_end + 1) = '\0';
          }
 
-         if (!strcmp(trimmed, section_header))
+         if (pgagroal_strcmp(trimmed, section_header))
          {
             in_section = true;
          }
@@ -792,7 +792,7 @@ config_get(const char* file_path, const char* section, const char* key)
                found_value = trim(found_value);
             }
 
-            if (!strcmp(found_key, key))
+            if (pgagroal_strcmp(found_key, key))
             {
                printf("%s\n", found_value);
                fclose(file);
@@ -885,7 +885,7 @@ config_set(const char* file_path, const char* section, const char* key, const ch
             *(bracket_end + 1) = '\0';
          }
 
-         if (!strcmp(trimmed, section_header))
+         if (pgagroal_strcmp(trimmed, section_header))
          {
             section_found = true;
             section_start = i;
@@ -913,7 +913,7 @@ config_set(const char* file_path, const char* section, const char* key, const ch
             {
                *eq = '\0';
                char* found_key = trim(kt);
-               if (!strcmp(found_key, key))
+               if (pgagroal_strcmp(found_key, key))
                {
                   key_found = true;
                   key_line = i;
@@ -1139,7 +1139,7 @@ config_del(const char* file_path, const char* section, const char* key)
          if (bracket_end)
             *(bracket_end + 1) = '\0';
 
-         if (!strcmp(trimmed, section_header))
+         if (pgagroal_strcmp(trimmed, section_header))
          {
             section_found = true;
             section_start = i;
@@ -1164,7 +1164,7 @@ config_del(const char* file_path, const char* section, const char* key)
             if (eq != NULL)
             {
                *eq = '\0';
-               if (!strcmp(trim(kt), key))
+               if (pgagroal_strcmp(trim(kt), key))
                {
                   key_line = i;
                }
@@ -1295,7 +1295,7 @@ config_ls(const char* file_path, const char* section)
 
          if (section != NULL)
          {
-            if (!strcmp(trimmed, section_header))
+            if (pgagroal_strcmp(trimmed, section_header))
             {
                in_section = true;
             }

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -547,7 +547,16 @@ pgagroal_indent(char* str, char* tag, int indent);
  * @return true if the strings are the same, otherwise false
  */
 bool
-pgagroal_compare_string(const char* str1, const char* str2);
+pgagroal_strcmp(const char* str1, const char* str2);
+
+/**
+ * Compare two strings case-insensitively
+ * @param str1 The first string
+ * @param str2 The second string
+ * @return true if the strings are the same, otherwise false
+ */
+bool
+pgagroal_strcasecmp(const char* str1, const char* str2);
 
 /**
  * Escape a string

--- a/src/libpgagroal/art.c
+++ b/src/libpgagroal/art.c
@@ -1742,7 +1742,7 @@ art_to_text_string_cb(void* param, const char* key, struct value* value)
    {
       tag = pgagroal_append(tag, " ");
    }
-   if (pgagroal_compare_string(p->tag, BULLET_POINT))
+   if (pgagroal_strcmp(p->tag, BULLET_POINT))
    {
       if (p->cnt == 1)
       {
@@ -1825,7 +1825,7 @@ to_text_string(struct art* t, char* tag, int indent)
 {
    char* ret = NULL;
    int next_indent = indent;
-   if (tag != NULL && !pgagroal_compare_string(tag, BULLET_POINT))
+   if (tag != NULL && !pgagroal_strcmp(tag, BULLET_POINT))
    {
       ret = pgagroal_indent(ret, tag, indent);
       next_indent += INDENT_PER_LEVEL;

--- a/src/libpgagroal/configuration.c
+++ b/src/libpgagroal/configuration.c
@@ -309,7 +309,7 @@ pgagroal_read_configuration(void* shm, char* filename, bool emit_warnings)
 
             idx_sections++;
 
-            if (strcmp(section, PGAGROAL_MAIN_INI_SECTION) && strcmp(section, "health_check") && strcmp(section, "prometheus"))
+            if (!pgagroal_strcmp(section, PGAGROAL_MAIN_INI_SECTION) && !pgagroal_strcmp(section, "health_check") && !pgagroal_strcmp(section, "prometheus"))
             {
                if (idx_server > 0 && idx_server <= NUMBER_OF_SERVERS)
                {
@@ -634,7 +634,7 @@ pgagroal_validate_configuration(void* shm, bool has_unix_socket, bool has_main_s
          return 1;
       }
 
-      if (strcmp(config->failover_script, config->failover_notify_script) == 0)
+      if (pgagroal_strcmp(config->failover_script, config->failover_notify_script))
       {
          pgagroal_log_fatal("pgagroal: failover_notify_script cannot be the same as failover_script");
          return 1;
@@ -1032,7 +1032,7 @@ pgagroal_vault_read_configuration(void* shm, char* filename, bool emit_warnings)
 
             idx_sections++;
 
-            if (strcmp(section, PGAGROAL_VAULT_INI_SECTION))
+            if (!pgagroal_strcmp(section, PGAGROAL_VAULT_INI_SECTION))
             {
                if (idx_server > 0 && idx_server <= 2)
                {
@@ -1372,8 +1372,8 @@ pgagroal_validate_hba_configuration(void* shm)
 
    for (int i = 0; i < config->number_of_hbas; i++)
    {
-      if (!strcasecmp("host", config->hbas[i].type) ||
-          !strcasecmp("hostssl", config->hbas[i].type))
+      if (pgagroal_strcasecmp("host", config->hbas[i].type) ||
+          pgagroal_strcasecmp("hostssl", config->hbas[i].type))
       {
          /* Ok */
       }
@@ -1383,11 +1383,11 @@ pgagroal_validate_hba_configuration(void* shm)
          return 1;
       }
 
-      if (!strcasecmp("trust", config->hbas[i].method) ||
-          !strcasecmp("reject", config->hbas[i].method) ||
-          !strcasecmp("password", config->hbas[i].method) ||
-          !strcasecmp("scram-sha-256", config->hbas[i].method) ||
-          !strcasecmp("all", config->hbas[i].method))
+      if (pgagroal_strcasecmp("trust", config->hbas[i].method) ||
+          pgagroal_strcasecmp("reject", config->hbas[i].method) ||
+          pgagroal_strcasecmp("password", config->hbas[i].method) ||
+          pgagroal_strcasecmp("scram-sha-256", config->hbas[i].method) ||
+          pgagroal_strcasecmp("all", config->hbas[i].method))
       {
          /* Ok */
       }
@@ -1564,7 +1564,7 @@ pgagroal_validate_limit_configuration(void* shm)
          // Check for duplicate aliases within the same limit entry
          for (int k = j + 1; k < config->limits[i].aliases_count; k++)
          {
-            if (!strcmp(config->limits[i].aliases[j], config->limits[i].aliases[k]))
+            if (pgagroal_strcmp(config->limits[i].aliases[j], config->limits[i].aliases[k]))
             {
                pgagroal_log_fatal("Duplicate alias '%s' found within limit entry %d (%s:%d)",
                                   config->limits[i].aliases[j], i + 1, config->limit_path, config->limits[i].lineno);
@@ -1575,7 +1575,7 @@ pgagroal_validate_limit_configuration(void* shm)
          // Check if alias conflicts with any main database name
          for (int k = 0; k < config->number_of_limits; k++)
          {
-            if (!strcmp(config->limits[i].aliases[j], config->limits[k].database))
+            if (pgagroal_strcmp(config->limits[i].aliases[j], config->limits[k].database))
             {
                pgagroal_log_fatal("Alias '%s' in entry %d conflicts with database name in entry %d (%s:%d vs %s:%d)",
                                   config->limits[i].aliases[j], i + 1, k + 1,
@@ -1594,7 +1594,7 @@ pgagroal_validate_limit_configuration(void* shm)
             }
             for (int l = 0; l < config->limits[k].aliases_count; l++)
             {
-               if (!strcmp(config->limits[i].aliases[j], config->limits[k].aliases[l]))
+               if (pgagroal_strcmp(config->limits[i].aliases[j], config->limits[k].aliases[l]))
                {
                   pgagroal_log_fatal("Duplicate alias '%s' found in entries %d and %d (%s:%d vs %s:%d)",
                                      config->limits[i].aliases[j], i + 1, k + 1,
@@ -1615,7 +1615,7 @@ pgagroal_validate_limit_configuration(void* shm)
          }
          for (int k = 0; k < config->limits[j].aliases_count; k++)
          {
-            if (!strcmp(config->limits[i].database, config->limits[j].aliases[k]))
+            if (pgagroal_strcmp(config->limits[i].database, config->limits[j].aliases[k]))
             {
                pgagroal_log_fatal("Database name '%s' in entry %d conflicts with alias in entry %d (%s:%d vs %s:%d)",
                                   config->limits[i].database, i + 1, j + 1,
@@ -1632,7 +1632,7 @@ pgagroal_validate_limit_configuration(void* shm)
 
          for (int j = 0; j < config->number_of_users; j++)
          {
-            if (!strcmp(config->limits[i].username, config->users[j].username))
+            if (pgagroal_strcmp(config->limits[i].username, config->users[j].username))
             {
                user_found = true;
             }
@@ -1962,7 +1962,7 @@ pgagroal_validate_frontend_users_configuration(void* shm)
       {
          char* u = &config->users[i].username[0];
 
-         if (!strcmp(f, u))
+         if (pgagroal_strcmp(f, u))
          {
             found = true;
          }
@@ -2184,7 +2184,7 @@ pgagroal_vault_read_users_configuration(void* shm, char* filename)
 
          if (strlen(username) < MAX_USERNAME_LENGTH &&
              strlen(password) < MAX_PASSWORD_LENGTH &&
-             !strcmp(config->vault_server.user.username, username))
+             pgagroal_strcmp(config->vault_server.user.username, username))
          {
             memcpy(&config->vault_server.user.password, password, strlen(password));
          }
@@ -2430,7 +2430,7 @@ pgagroal_reload_configuration(bool* r, bool* health_check_changed)
       goto error;
    }
 
-   if (strcmp("", config->limit_path))
+   if (!pgagroal_strcmp("", config->limit_path))
    {
       if (pgagroal_read_limit_configuration((void*)reload, config->limit_path))
       {
@@ -2438,7 +2438,7 @@ pgagroal_reload_configuration(bool* r, bool* health_check_changed)
       }
    }
 
-   if (strcmp("", config->users_path))
+   if (!pgagroal_strcmp("", config->users_path))
    {
       if (pgagroal_read_users_configuration((void*)reload, config->users_path))
       {
@@ -2446,7 +2446,7 @@ pgagroal_reload_configuration(bool* r, bool* health_check_changed)
       }
    }
 
-   if (strcmp("", config->frontend_users_path))
+   if (!pgagroal_strcmp("", config->frontend_users_path))
    {
       if (pgagroal_read_frontend_users_configuration((void*)reload, config->frontend_users_path))
       {
@@ -2454,7 +2454,7 @@ pgagroal_reload_configuration(bool* r, bool* health_check_changed)
       }
    }
 
-   if (strcmp("", config->admins_path))
+   if (!pgagroal_strcmp("", config->admins_path))
    {
       if (pgagroal_read_admins_configuration((void*)reload, config->admins_path))
       {
@@ -2462,7 +2462,7 @@ pgagroal_reload_configuration(bool* r, bool* health_check_changed)
       }
    }
 
-   if (strcmp("", config->superuser_path))
+   if (!pgagroal_strcmp("", config->superuser_path))
    {
       if (pgagroal_read_superuser_configuration((void*)reload, config->superuser_path))
       {
@@ -2813,13 +2813,13 @@ error:
 int
 pgagroal_as_bool(char* str, bool* b)
 {
-   if (!strcasecmp(str, "true") || !strcasecmp(str, "on") || !strcasecmp(str, "yes") || !strcasecmp(str, "1"))
+   if (pgagroal_strcasecmp(str, "true") || pgagroal_strcasecmp(str, "on") || pgagroal_strcasecmp(str, "yes") || pgagroal_strcasecmp(str, "1"))
    {
       *b = true;
       return 0;
    }
 
-   if (!strcasecmp(str, "false") || !strcasecmp(str, "off") || !strcasecmp(str, "no") || !strcasecmp(str, "0"))
+   if (pgagroal_strcasecmp(str, "false") || pgagroal_strcasecmp(str, "off") || pgagroal_strcasecmp(str, "no") || pgagroal_strcasecmp(str, "0"))
    {
       *b = false;
       return 0;
@@ -2831,19 +2831,19 @@ pgagroal_as_bool(char* str, bool* b)
 int
 pgagroal_as_logging_type(char* str, int* type)
 {
-   if (!strcasecmp(str, "console"))
+   if (pgagroal_strcasecmp(str, "console"))
    {
       *type = PGAGROAL_LOGGING_TYPE_CONSOLE;
       return 0;
    }
 
-   if (!strcasecmp(str, "file"))
+   if (pgagroal_strcasecmp(str, "file"))
    {
       *type = PGAGROAL_LOGGING_TYPE_FILE;
       return 0;
    }
 
-   if (!strcasecmp(str, "syslog"))
+   if (pgagroal_strcasecmp(str, "syslog"))
    {
       *type = PGAGROAL_LOGGING_TYPE_SYSLOG;
       return 0;
@@ -2906,28 +2906,28 @@ pgagroal_as_logging_level(char* str)
       }
    }
 
-   if (!strcasecmp(str, "info"))
+   if (pgagroal_strcasecmp(str, "info"))
    {
       return PGAGROAL_LOGGING_LEVEL_INFO;
    }
 
-   if (!strcasecmp(str, "warn"))
+   if (pgagroal_strcasecmp(str, "warn"))
    {
       return PGAGROAL_LOGGING_LEVEL_WARN;
    }
 
-   if (!strcasecmp(str, "error"))
+   if (pgagroal_strcasecmp(str, "error"))
    {
       return PGAGROAL_LOGGING_LEVEL_ERROR;
    }
 
-   if (!strcasecmp(str, "fatal"))
+   if (pgagroal_strcasecmp(str, "fatal"))
    {
       return PGAGROAL_LOGGING_LEVEL_FATAL;
    }
 
    // "trace" is a synonym for "debug5"
-   if (!strcasecmp(str, "trace"))
+   if (pgagroal_strcasecmp(str, "trace"))
    {
       return PGAGROAL_LOGGING_LEVEL_DEBUG5;
    }
@@ -2938,13 +2938,13 @@ pgagroal_as_logging_level(char* str)
 int
 pgagroal_as_logging_mode(char* str, int* mode)
 {
-   if (!strcasecmp(str, "a") || !strcasecmp(str, "append"))
+   if (pgagroal_strcasecmp(str, "a") || pgagroal_strcasecmp(str, "append"))
    {
       *mode = PGAGROAL_LOGGING_MODE_APPEND;
       return 0;
    }
 
-   if (!strcasecmp(str, "c") || !strcasecmp(str, "create"))
+   if (pgagroal_strcasecmp(str, "c") || pgagroal_strcasecmp(str, "create"))
    {
       *mode = PGAGROAL_LOGGING_MODE_CREATE;
       return 0;
@@ -2956,19 +2956,19 @@ pgagroal_as_logging_mode(char* str, int* mode)
 int
 pgagroal_as_validation(char* str, int* val)
 {
-   if (!strcasecmp(str, "off"))
+   if (pgagroal_strcasecmp(str, "off"))
    {
       *val = VALIDATION_OFF;
       return 0;
    }
 
-   if (!strcasecmp(str, "foreground"))
+   if (pgagroal_strcasecmp(str, "foreground"))
    {
       *val = VALIDATION_FOREGROUND;
       return 0;
    }
 
-   if (!strcasecmp(str, "background"))
+   if (pgagroal_strcasecmp(str, "background"))
    {
       *val = VALIDATION_BACKGROUND;
       return 0;
@@ -2980,17 +2980,17 @@ pgagroal_as_validation(char* str, int* val)
 int
 pgagroal_as_server_reset_query_behavior_on_failure(char* str, int* val)
 {
-   if (!strcasecmp(str, "discard"))
+   if (pgagroal_strcasecmp(str, "discard"))
    {
       *val = SERVER_RESET_QUERY_BEHAVIOR_ON_FAILURE_DISCARD;
       return 0;
    }
-   if (!strcasecmp(str, "ignore"))
+   if (pgagroal_strcasecmp(str, "ignore"))
    {
       *val = SERVER_RESET_QUERY_BEHAVIOR_ON_FAILURE_IGNORE;
       return 0;
    }
-   if (!strcasecmp(str, "try"))
+   if (pgagroal_strcasecmp(str, "try"))
    {
       *val = SERVER_RESET_QUERY_BEHAVIOR_ON_FAILURE_TRY;
       return 0;
@@ -3001,25 +3001,25 @@ pgagroal_as_server_reset_query_behavior_on_failure(char* str, int* val)
 int
 pgagroal_as_pipeline(char* str, int* pipeline)
 {
-   if (!strcasecmp(str, "auto"))
+   if (pgagroal_strcasecmp(str, "auto"))
    {
       *pipeline = PIPELINE_AUTO;
       return 0;
    }
 
-   if (!strcasecmp(str, "performance"))
+   if (pgagroal_strcasecmp(str, "performance"))
    {
       *pipeline = PIPELINE_PERFORMANCE;
       return 0;
    }
 
-   if (!strcasecmp(str, "session"))
+   if (pgagroal_strcasecmp(str, "session"))
    {
       *pipeline = PIPELINE_SESSION;
       return 0;
    }
 
-   if (!strcasecmp(str, "transaction"))
+   if (pgagroal_strcasecmp(str, "transaction"))
    {
       *pipeline = PIPELINE_TRANSACTION;
       return 0;
@@ -3031,19 +3031,19 @@ pgagroal_as_pipeline(char* str, int* pipeline)
 int
 pgagroal_as_hugepage(char* str, unsigned char* hp)
 {
-   if (!strcasecmp(str, "off"))
+   if (pgagroal_strcasecmp(str, "off"))
    {
       *hp = HUGEPAGE_OFF;
       return 0;
    }
 
-   if (!strcasecmp(str, "try"))
+   if (pgagroal_strcasecmp(str, "try"))
    {
       *hp = HUGEPAGE_TRY;
       return 0;
    }
 
-   if (!strcasecmp(str, "on"))
+   if (pgagroal_strcasecmp(str, "on"))
    {
       *hp = HUGEPAGE_ON;
       return 0;
@@ -3055,19 +3055,19 @@ pgagroal_as_hugepage(char* str, unsigned char* hp)
 int
 pgagroal_as_channel_binding(char* str, unsigned char* cb)
 {
-   if (!strcasecmp(str, "disabled"))
+   if (pgagroal_strcasecmp(str, "disabled"))
    {
       *cb = CHANNEL_BINDING_DISABLED;
       return 0;
    }
 
-   if (!strcasecmp(str, "prefer"))
+   if (pgagroal_strcasecmp(str, "prefer"))
    {
       *cb = CHANNEL_BINDING_PREFER;
       return 0;
    }
 
-   if (!strcasecmp(str, "require"))
+   if (pgagroal_strcasecmp(str, "require"))
    {
       *cb = CHANNEL_BINDING_REQUIRE;
       return 0;
@@ -3079,19 +3079,19 @@ pgagroal_as_channel_binding(char* str, unsigned char* cb)
 int
 pgagroal_as_startup_validation(char* str, int* sv)
 {
-   if (!strcasecmp(str, "off"))
+   if (pgagroal_strcasecmp(str, "off"))
    {
       *sv = STARTUP_VALIDATION_OFF;
       return 0;
    }
 
-   if (!strcasecmp(str, "try"))
+   if (pgagroal_strcasecmp(str, "try"))
    {
       *sv = STARTUP_VALIDATION_TRY;
       return 0;
    }
 
-   if (!strcasecmp(str, "on"))
+   if (pgagroal_strcasecmp(str, "on"))
    {
       *sv = STARTUP_VALIDATION_ON;
       return 0;
@@ -3317,7 +3317,7 @@ extract_limit(char* str, int server_max, char** database, char** user, int* max_
       goto cleanup;
    }
 
-   if (!strcasecmp("all", value))
+   if (pgagroal_strcasecmp("all", value))
    {
       *max_size = server_max;
    }
@@ -3334,9 +3334,9 @@ extract_limit(char* str, int server_max, char** database, char** user, int* max_
 
    // Extract initial_size (optional)
    offset = extract_value(str, offset, &value);
-   if (offset != -1 && value && strcmp("", value) != 0)
+   if (offset != -1 && value && !pgagroal_strcmp("", value))
    {
-      if (!strcasecmp("all", value))
+      if (pgagroal_strcasecmp("all", value))
       {
          *initial_size = server_max;
       }
@@ -3353,9 +3353,9 @@ extract_limit(char* str, int server_max, char** database, char** user, int* max_
 
    // Extract min_size (optional)
    offset = extract_value(str, offset, &value);
-   if (offset != -1 && value && strcmp("", value) != 0)
+   if (offset != -1 && value && !pgagroal_strcmp("", value))
    {
-      if (!strcasecmp("all", value))
+      if (pgagroal_strcasecmp("all", value))
       {
          *min_size = server_max;
       }
@@ -4169,7 +4169,7 @@ restart_string(char* name, char* e, char* n, bool skip_non_existing)
       return 0;
    }
 
-   if (strcmp(e, n))
+   if (!pgagroal_strcmp(e, n))
    {
       pgagroal_log_warn("Restart required for %s - Existing %s New %s", name, e, n);
       return 1;
@@ -4197,8 +4197,8 @@ restart_limit(char* name __attribute__((unused)), struct main_configuration* con
       e = &config->limits[i];
       n = &reload->limits[i];
 
-      if (strcmp(e->database, n->database) ||
-          strcmp(e->username, n->username) ||
+      if (!pgagroal_strcmp(e->database, n->database) ||
+          !pgagroal_strcmp(e->username, n->username) ||
           e->max_size != n->max_size ||
           e->initial_size != n->initial_size ||
           e->min_size != n->min_size)
@@ -4218,7 +4218,7 @@ restart_limit(char* name __attribute__((unused)), struct main_configuration* con
       bool aliases_changed = false;
       for (int j = 0; j < n->aliases_count; j++)
       {
-         if (j >= e->aliases_count || strcmp(e->aliases[j], n->aliases[j]) != 0)
+         if (j >= e->aliases_count || !pgagroal_strcmp(e->aliases[j], n->aliases[j]))
          {
             aliases_changed = true;
             break;
@@ -4287,7 +4287,7 @@ health_check_settings_changed(struct main_configuration* config, struct main_con
       return true;
    }
 
-   if (strcmp(config->health_check_user, reload->health_check_user))
+   if (!pgagroal_strcmp(config->health_check_user, reload->health_check_user))
    {
       return true;
    }
@@ -4314,7 +4314,7 @@ is_empty_string(char* s)
       return true;
    }
 
-   if (!strcmp(s, ""))
+   if (pgagroal_strcmp(s, ""))
    {
       return true;
    }
@@ -6475,11 +6475,11 @@ pgagroal_apply_vault_configuration(struct vault_configuration* config,
    }
    else if (key_in_section("tls_cert_auth_mode", section, key, true, &unknown))
    {
-      if (!strcasecmp(value, "verify-ca"))
+      if (pgagroal_strcasecmp(value, "verify-ca"))
       {
          config->tls_cert_auth_mode = TLS_CERT_AUTH_MODE_VERIFY_CA;
       }
-      else if (!strcasecmp(value, "verify-full"))
+      else if (pgagroal_strcasecmp(value, "verify-full"))
       {
          config->tls_cert_auth_mode = TLS_CERT_AUTH_MODE_VERIFY_FULL;
       }

--- a/src/libpgagroal/console.c
+++ b/src/libpgagroal/console.c
@@ -198,11 +198,11 @@ resolve_page(struct message* msg)
 
    pgagroal_write_byte(msg->data + index, '\0');
 
-   if (strcmp(from, "/") == 0 || strcmp(from, "/index.html") == 0)
+   if (pgagroal_strcmp(from, "/") || pgagroal_strcmp(from, "/index.html"))
    {
       return PAGE_HOME;
    }
-   else if (strcmp(from, "/api") == 0 || strcmp(from, "/api/") == 0)
+   else if (pgagroal_strcmp(from, "/api") || pgagroal_strcmp(from, "/api/"))
    {
       return PAGE_API;
    }
@@ -435,9 +435,9 @@ console_refresh_metrics(int endpoint, struct console_page* console)
          }
 
          effective_endpoint = 0;
-         resolved_host = (strlen(config->common.host) == 0 || strcmp(config->common.host, "*") == 0 || strcmp(config->common.host, "0.0.0.0") == 0) ? "127.0.0.1" : config->common.host;
+         resolved_host = (strlen(config->common.host) == 0 || pgagroal_strcmp(config->common.host, "*") || pgagroal_strcmp(config->common.host, "0.0.0.0")) ? "127.0.0.1" : config->common.host;
 
-         if (strcmp(resolved_host, config->common.host) != 0)
+         if (!pgagroal_strcmp(resolved_host, config->common.host))
          {
             memset(original_host, 0, sizeof(original_host));
             pgagroal_snprintf(original_host, sizeof(original_host), "%s", config->common.host);
@@ -611,7 +611,7 @@ console_refresh_status(struct console_page* console)
          {
             struct json* server = (struct json*)(iter->value->data);
             char* state = (char*)pgagroal_json_get(server, MANAGEMENT_ARGUMENT_STATE);
-            bool active = state != NULL && (!strcmp(state, "Primary") || !strcmp(state, "Replica"));
+            bool active = state != NULL && (pgagroal_strcmp(state, "Primary") || pgagroal_strcmp(state, "Replica"));
             char* server_name = (char*)pgagroal_json_get(server, MANAGEMENT_ARGUMENT_SERVER);
 
             if (console->status->servers != NULL)
@@ -1296,7 +1296,7 @@ find_or_create_category(struct console_page* console, char* category_name)
    /* Try to find existing */
    for (int i = 0; i < console->category_count; i++)
    {
-      if (strcmp(console->categories[i].name, category_name) == 0)
+      if (pgagroal_strcmp(console->categories[i].name, category_name))
       {
          return &console->categories[i];
       }
@@ -1448,7 +1448,7 @@ extract_labels_from_prometheus_attrs(struct prometheus_attributes* attrs, struct
          continue;
       }
 
-      if (strcmp(attr->key, "server") == 0 || strcmp(attr->key, "name") == 0)
+      if (pgagroal_strcmp(attr->key, "server") || pgagroal_strcmp(attr->key, "name"))
       {
          free(metric->server);
          metric->server = strdup(attr->value);
@@ -1498,7 +1498,7 @@ add_or_increment_prefix(struct prefix_count** counts, int* size, int* capacity, 
    /* Find existing prefix */
    for (int j = 0; j < *size; j++)
    {
-      if (strcmp((*counts)[j].prefix, prefix) == 0)
+      if (pgagroal_strcmp((*counts)[j].prefix, prefix))
       {
          found = j;
          break;
@@ -1920,14 +1920,14 @@ collect_simple_label_columns(struct console_category* category, char*** label_ke
             continue;
          }
 
-         if (strcmp(key, "endpoint") == 0)
+         if (pgagroal_strcmp(key, "endpoint"))
          {
             continue;
          }
 
          for (int i = 0; i < count; i++)
          {
-            if (strcmp(keys[i], key) == 0)
+            if (pgagroal_strcmp(keys[i], key))
             {
                exists = true;
                break;
@@ -1987,7 +1987,7 @@ find_metric_label_value(struct console_metric* metric, const char* key)
          continue;
       }
 
-      if (strcmp(metric->labels[i].key, key) == 0)
+      if (pgagroal_strcmp(metric->labels[i].key, key))
       {
          return metric->labels[i].value;
       }

--- a/src/libpgagroal/deque.c
+++ b/src/libpgagroal/deque.c
@@ -124,7 +124,7 @@ pgagroal_deque_remove(struct deque* deque, char* tag)
    pgagroal_deque_iterator_create(deque, &iter);
    while (pgagroal_deque_iterator_next(iter))
    {
-      if (pgagroal_compare_string(iter->tag, tag))
+      if (pgagroal_strcmp(iter->tag, tag))
       {
          pgagroal_deque_iterator_remove(iter);
          cnt++;
@@ -618,7 +618,7 @@ deque_find(struct deque* deque, char* tag)
 
    while (n != NULL)
    {
-      if (pgagroal_compare_string(tag, n->tag))
+      if (pgagroal_strcmp(tag, n->tag))
       {
          return n;
       }
@@ -706,9 +706,9 @@ to_text_string(struct deque* deque, char* tag, int indent)
 {
    char* ret = NULL;
    int cnt = 0;
-   int next_indent = pgagroal_compare_string(tag, BULLET_POINT) ? 0 : indent;
+   int next_indent = pgagroal_strcmp(tag, BULLET_POINT) ? 0 : indent;
    // we have a tag and it's not the bullet point, so that means another line
-   if (tag != NULL && !pgagroal_compare_string(tag, BULLET_POINT))
+   if (tag != NULL && !pgagroal_strcmp(tag, BULLET_POINT))
    {
       ret = pgagroal_indent(ret, tag, indent);
       next_indent += INDENT_PER_LEVEL;
@@ -729,7 +729,7 @@ to_text_string(struct deque* deque, char* tag, int indent)
       if (cnt == 0)
       {
          cnt++;
-         if (pgagroal_compare_string(tag, BULLET_POINT))
+         if (pgagroal_strcmp(tag, BULLET_POINT))
          {
             next_indent = indent + INDENT_PER_LEVEL;
          }

--- a/src/libpgagroal/health.c
+++ b/src/libpgagroal/health.c
@@ -219,7 +219,7 @@ health_check_loop(void)
                                                                      slot_name, sizeof(slot_name),
                                                                      sender_host, sizeof(sender_host),
                                                                      sender_port, sizeof(sender_port));
-            bool is_streaming = pgagroal_compare_string(rep_status, "streaming");
+            bool is_streaming = pgagroal_strcmp(rep_status, "streaming");
 
             if (wal_result == 0)
             {

--- a/src/libpgagroal/json.c
+++ b/src/libpgagroal/json.c
@@ -643,15 +643,15 @@ fill_value(char* str, char* key, uint64_t* index, struct json* o)
       {
          val = pgagroal_append_char(val, str[idx++]);
       }
-      if (pgagroal_compare_string(val, "null"))
+      if (pgagroal_strcmp(val, "null"))
       {
          json_add(o, key, 0, ValueString);
       }
-      else if (pgagroal_compare_string(val, "true"))
+      else if (pgagroal_strcmp(val, "true"))
       {
          json_add(o, key, true, ValueBool);
       }
-      else if (pgagroal_compare_string(val, "false"))
+      else if (pgagroal_strcmp(val, "false"))
       {
          json_add(o, key, false, ValueBool);
       }

--- a/src/libpgagroal/management.c
+++ b/src/libpgagroal/management.c
@@ -965,7 +965,7 @@ pgagroal_management_response_error(SSL* ssl, int socket, char* server, int32_t e
       {
          FOREACH_VALID_SERVER
          {
-            if (!strcmp(server, config->servers[i].name))
+            if (pgagroal_strcmp(server, config->servers[i].name))
             {
                srv = i;
             }

--- a/src/libpgagroal/network.c
+++ b/src/libpgagroal/network.c
@@ -71,7 +71,7 @@ pgagroal_bind(const char* hostname, int port, int** fds, int* length, bool no_de
    int* star_fds = NULL;
    int star_length = 0;
 
-   if (!strcmp("*", hostname))
+   if (pgagroal_strcmp("*", hostname))
    {
       if (getifaddrs(&ifaddr) == -1)
       {

--- a/src/libpgagroal/pipeline_transaction.c
+++ b/src/libpgagroal/pipeline_transaction.c
@@ -265,7 +265,7 @@ transaction_client(struct io_watcher* watcher)
                   if (kind == 'P')
                   {
                      char* ps = pgagroal_read_string(msg->data + offset + 5);
-                     if (strcmp(ps, ""))
+                     if (!pgagroal_strcmp(ps, ""))
                      {
                         deallocate = true;
                      }

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -127,11 +127,11 @@ start:
 
             // Check if same rule and username
             if (best_rule == config->connections[i].limit_rule &&
-                !strcmp((const char*)(&config->connections[i].username), username))
+                pgagroal_strcmp((const char*)(&config->connections[i].username), username))
             {
                real_database = resolve_database_name(database, best_rule);
                // Check exact database match
-               if (!strcmp((const char*)(&config->connections[i].database), real_database))
+               if (pgagroal_strcmp((const char*)(&config->connections[i].database), real_database))
                {
                   can_reuse = true;
                }
@@ -1072,7 +1072,7 @@ pgagroal_flush(int mode, char* database)
       {
          bool consider = false;
 
-         if (!strcmp(database, "all") || !strcmp(config->connections[i].database, database))
+         if (pgagroal_strcmp(database, "all") || pgagroal_strcmp(config->connections[i].database, database))
          {
             consider = true;
          }
@@ -1305,13 +1305,13 @@ pgagroal_prefill(bool initial)
             continue;
          }
 
-         if (strcmp("all", config->limits[i].database) && strcmp("all", config->limits[i].username))
+         if (!pgagroal_strcmp("all", config->limits[i].database) && !pgagroal_strcmp("all", config->limits[i].username))
          {
             int user = -1;
 
             for (int j = 0; j < config->number_of_users && user == -1; j++)
             {
-               if (!strcmp(config->limits[i].username, config->users[j].username))
+               if (pgagroal_strcmp(config->limits[i].username, config->users[j].username))
                {
                   user = j;
                }
@@ -1492,7 +1492,7 @@ find_best_rule(char* username, char* database)
          bool database_match = false;
 
          // Check exact database name match or "all"
-         if (!strcmp("all", config->limits[i].database) || !strcmp(database, config->limits[i].database))
+         if (pgagroal_strcmp("all", config->limits[i].database) || pgagroal_strcmp(database, config->limits[i].database))
          {
             database_match = true;
          }
@@ -1501,7 +1501,7 @@ find_best_rule(char* username, char* database)
             // Check if database matches any alias for this limit entry
             for (int j = 0; j < config->limits[i].aliases_count; j++)
             {
-               if (!strcmp(database, config->limits[i].aliases[j]))
+               if (pgagroal_strcmp(database, config->limits[i].aliases[j]))
                {
                   database_match = true;
                   pgagroal_log_debug("Database '%s' matched alias '%s' for rule %d",
@@ -1512,7 +1512,7 @@ find_best_rule(char* username, char* database)
          }
 
          // Check username match
-         bool username_match = (!strcmp("all", config->limits[i].username) || !strcmp(username, config->limits[i].username));
+         bool username_match = (pgagroal_strcmp("all", config->limits[i].username) || pgagroal_strcmp(username, config->limits[i].username));
 
          /* There is a match */
          if (username_match && database_match)
@@ -1523,24 +1523,24 @@ find_best_rule(char* username, char* database)
             }
             else
             {
-               if (!strcmp(username, config->limits[best_rule].username) &&
-                   (!strcmp(database, config->limits[best_rule].database) ||
+               if (pgagroal_strcmp(username, config->limits[best_rule].username) &&
+                   (pgagroal_strcmp(database, config->limits[best_rule].database) ||
                     is_alias_of_limit(database, best_rule)))
                {
                   /* We have a precise rule already */
                }
-               else if (!strcmp("all", config->limits[best_rule].username))
+               else if (pgagroal_strcmp("all", config->limits[best_rule].username))
                {
                   /* User is better */
-                  if (strcmp("all", config->limits[i].username))
+                  if (!pgagroal_strcmp("all", config->limits[i].username))
                   {
                      best_rule = i;
                   }
                }
-               else if (!strcmp("all", config->limits[best_rule].database))
+               else if (pgagroal_strcmp("all", config->limits[best_rule].database))
                {
                   /* Database is better */
-                  if (strcmp("all", config->limits[i].database))
+                  if (!pgagroal_strcmp("all", config->limits[i].database))
                   {
                      best_rule = i;
                   }
@@ -1571,7 +1571,7 @@ is_alias_of_limit(char* database, int limit_index)
 
    for (int i = 0; i < config->limits[limit_index].aliases_count; i++)
    {
-      if (!strcmp(database, config->limits[limit_index].aliases[i]))
+      if (pgagroal_strcmp(database, config->limits[limit_index].aliases[i]))
       {
          return true;
       }
@@ -1627,10 +1627,10 @@ get_connection_count_for_limit_rule(int rule_index, char* username)
    for (int i = 0; i < config->max_connections; i++)
    {
       if (atomic_load(&config->states[i]) != STATE_NOTINIT &&
-          !strcmp((const char*)(&config->connections[i].username), username))
+          pgagroal_strcmp((const char*)(&config->connections[i].username), username))
       {
          // Check if this connection is for the main database name
-         if (!strcmp((const char*)(&config->connections[i].database), config->limits[rule_index].database))
+         if (pgagroal_strcmp((const char*)(&config->connections[i].database), config->limits[rule_index].database))
          {
             count++;
          }
@@ -1639,7 +1639,7 @@ get_connection_count_for_limit_rule(int rule_index, char* username)
             // Check if this connection is for any alias of this database
             for (int j = 0; j < config->limits[rule_index].aliases_count; j++)
             {
-               if (!strcmp((const char*)(&config->connections[i].database), config->limits[rule_index].aliases[j]))
+               if (pgagroal_strcmp((const char*)(&config->connections[i].database), config->limits[rule_index].aliases[j]))
                {
                   count++;
                   break;
@@ -1672,7 +1672,7 @@ remove_connection(char* username, char* database)
 
       if (atomic_compare_exchange_strong(&config->states[i], &free, remove))
       {
-         if (!strcmp(username, config->connections[i].username) && !strcmp(database, config->connections[i].database))
+         if (pgagroal_strcmp(username, config->connections[i].username) && pgagroal_strcmp(database, config->connections[i].database))
          {
             if (!atomic_compare_exchange_strong(&config->states[i], &remove, STATE_FREE))
             {
@@ -2000,8 +2000,8 @@ do_prefill(char* username, char* database, int size)
       // Fallback to old logic if no rule found
       for (int i = 0; i < config->max_connections; i++)
       {
-         if (!strcmp((const char*)(&config->connections[i].username), username) &&
-             !strcmp((const char*)(&config->connections[i].database), database))
+         if (pgagroal_strcmp((const char*)(&config->connections[i].username), username) &&
+             pgagroal_strcmp((const char*)(&config->connections[i].database), database))
          {
             connections++;
          }
@@ -2064,7 +2064,7 @@ resolve_database_name(char* database, int best_rule)
    // Check if this database name is an alias
    for (int j = 0; j < config->limits[best_rule].aliases_count; j++)
    {
-      if (!strcmp(database, config->limits[best_rule].aliases[j]))
+      if (pgagroal_strcmp(database, config->limits[best_rule].aliases[j]))
       {
          return config->limits[best_rule].database; // Return real database name
       }

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -1249,11 +1249,11 @@ resolve_page(struct message* msg)
 
    pgagroal_write_byte(msg->data + index, '\0');
 
-   if (strcmp(from, "/") == 0 || strcmp(from, "/index.html") == 0)
+   if (pgagroal_strcmp(from, "/") || pgagroal_strcmp(from, "/index.html"))
    {
       return PAGE_HOME;
    }
-   else if (strcmp(from, "/metrics") == 0)
+   else if (pgagroal_strcmp(from, "/metrics"))
    {
       return PAGE_METRICS;
    }

--- a/src/libpgagroal/prometheus_client.c
+++ b/src/libpgagroal/prometheus_client.c
@@ -730,7 +730,7 @@ attributes_contains(struct deque* attributes, struct prometheus_attribute* attri
       {
          struct prometheus_attribute* a = (struct prometheus_attribute*)attributes_iterator->value->data;
 
-         if (!strcmp(a->key, attribute->key) && !strcmp(a->value, attribute->value))
+         if (pgagroal_strcmp(a->key, attribute->key) && pgagroal_strcmp(a->value, attribute->value))
          {
             found = true;
          }
@@ -1401,7 +1401,7 @@ parse_body_to_bridge(time_t timestamp, char* body, struct prometheus_bridge* bri
 
    while (line != NULL)
    {
-      if (line[0] == '\0' || !strcmp(line, "\r"))
+      if (line[0] == '\0' || pgagroal_strcmp(line, "\r"))
       {
          line = strtok_r(NULL, "\n", &saveptr);
          continue;

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -750,7 +750,7 @@ pgagroal_remote_management_auth(int client_fd, char* address, SSL** client_ssl)
       pgagroal_extract_username_database(request_msg, &username, &database, &appname);
 
       /* Must be admin database */
-      if (strcmp("admin", database) != 0)
+      if (!pgagroal_strcmp("admin", database))
       {
          pgagroal_log_debug("remote_management_auth: admin: %s / %s", username, address);
          pgagroal_write_connection_refused(c_ssl, client_fd);
@@ -1907,7 +1907,7 @@ retry:
       goto error;
    }
 
-   if (strcmp(pgagroal_read_string(msg->data + 5), password))
+   if (!pgagroal_strcmp(pgagroal_read_string(msg->data + 5), password))
    {
       pgagroal_write_bad_password(c_ssl, client_fd, username);
 
@@ -2013,7 +2013,7 @@ retry:
       size_t gs2_length = 0;
       int commas = 0;
 
-      client_plus = strcmp(mechanism, "SCRAM-SHA-256-PLUS") == 0;
+      client_plus = pgagroal_strcmp(mechanism, "SCRAM-SHA-256-PLUS");
 
       /* The initial response follows the mechanism NUL and its int32 length */
       header = 5 + strlen(mechanism) + 1 + 4;
@@ -2787,7 +2787,7 @@ scram_mechanism_offered(char* sasl, size_t sasl_length, const char* name)
       {
          break;
       }
-      if (!strcmp(mechanism, name))
+      if (pgagroal_strcmp(mechanism, name))
       {
          return true;
       }
@@ -2822,7 +2822,7 @@ scram_strip_channel_binding(struct message* msg)
       char* mechanism = data + offset;
       size_t len = strlen(mechanism);
 
-      if (strcmp(mechanism, "SCRAM-SHA-256-PLUS"))
+      if (!pgagroal_strcmp(mechanism, "SCRAM-SHA-256-PLUS"))
       {
          if (out != offset)
          {
@@ -3193,7 +3193,7 @@ is_allowed(char* username, char* database, char* address, int* hba_method)
 static bool
 is_allowed_username(char* username, char* entry)
 {
-   if (!strcasecmp(entry, "all") || !strcmp(username, entry))
+   if (pgagroal_strcasecmp(entry, "all") || pgagroal_strcmp(username, entry))
    {
       return true;
    }
@@ -3206,7 +3206,7 @@ is_allowed_database(char* database, char* entry)
 {
    struct main_configuration* config = (struct main_configuration*)shmem;
 
-   if (!strcasecmp(entry, "all") || !strcmp(database, entry))
+   if (pgagroal_strcasecmp(entry, "all") || pgagroal_strcmp(database, entry))
    {
       return true;
    }
@@ -3214,12 +3214,12 @@ is_allowed_database(char* database, char* entry)
    // Check if the database is an alias in any limit entry
    for (int i = 0; i < config->number_of_limits; i++)
    {
-      if (!strcmp(entry, config->limits[i].database))
+      if (pgagroal_strcmp(entry, config->limits[i].database))
       {
          // Check if database is an alias of this entry
          for (int j = 0; j < config->limits[i].aliases_count; j++)
          {
-            if (!strcmp(database, config->limits[i].aliases[j]))
+            if (pgagroal_strcmp(database, config->limits[i].aliases[j]))
             {
                pgagroal_log_debug("HBA: Database '%s' matched as alias of '%s'", database, entry);
                return true;
@@ -3247,7 +3247,7 @@ is_allowed_address(char* address, char* entry)
    memset(&addr, 0, sizeof(addr));
    memset(&s_mask, 0, sizeof(s_mask));
 
-   if (!strcasecmp(entry, "all"))
+   if (pgagroal_strcasecmp(entry, "all"))
    {
       return true;
    }
@@ -3295,7 +3295,7 @@ is_allowed_address(char* address, char* entry)
 
    if (ipv4)
    {
-      if (!strcmp(entry, "0.0.0.0/0"))
+      if (pgagroal_strcmp(entry, "0.0.0.0/0"))
       {
          return true;
       }
@@ -3335,7 +3335,7 @@ is_allowed_address(char* address, char* entry)
    }
    else
    {
-      if (!strcmp(entry, "::0/0"))
+      if (pgagroal_strcmp(entry, "::0/0"))
       {
          return true;
       }
@@ -3381,7 +3381,7 @@ is_disabled(char* database)
 
    for (int i = 0; i < NUMBER_OF_DISABLED; i++)
    {
-      if (!strcmp(config->disabled[i], database))
+      if (pgagroal_strcmp(config->disabled[i], database))
       {
          return true;
       }
@@ -3397,27 +3397,27 @@ get_hba_method(int index)
 
    config = (struct main_configuration*)shmem;
 
-   if (!strcasecmp(config->hbas[index].method, "reject"))
+   if (pgagroal_strcasecmp(config->hbas[index].method, "reject"))
    {
       return SECURITY_REJECT;
    }
 
-   if (!strcasecmp(config->hbas[index].method, "trust"))
+   if (pgagroal_strcasecmp(config->hbas[index].method, "trust"))
    {
       return SECURITY_TRUST;
    }
 
-   if (!strcasecmp(config->hbas[index].method, "password"))
+   if (pgagroal_strcasecmp(config->hbas[index].method, "password"))
    {
       return SECURITY_PASSWORD;
    }
 
-   if (!strcasecmp(config->hbas[index].method, "scram-sha-256"))
+   if (pgagroal_strcasecmp(config->hbas[index].method, "scram-sha-256"))
    {
       return SECURITY_SCRAM256;
    }
 
-   if (!strcasecmp(config->hbas[index].method, "all"))
+   if (pgagroal_strcasecmp(config->hbas[index].method, "all"))
    {
       return SECURITY_ALL;
    }
@@ -3432,14 +3432,14 @@ pgagroal_get_user_password(char* username)
 
    config = (struct main_configuration*)shmem;
 
-   if (config->superuser.username[0] != 0 && !strcmp(config->superuser.username, username))
+   if (config->superuser.username[0] != 0 && pgagroal_strcmp(config->superuser.username, username))
    {
       return config->superuser.password;
    }
 
    for (int i = 0; i < config->number_of_users; i++)
    {
-      if (!strcmp(&config->users[i].username[0], username))
+      if (pgagroal_strcmp(&config->users[i].username[0], username))
       {
          return &config->users[i].password[0];
       }
@@ -3457,7 +3457,7 @@ get_frontend_password(char* username)
 
    for (int i = 0; i < config->number_of_frontend_users; i++)
    {
-      if (!strcmp(&config->frontend_users[i].username[0], username))
+      if (pgagroal_strcmp(&config->frontend_users[i].username[0], username))
       {
          return &config->frontend_users[i].password[0];
       }
@@ -3475,7 +3475,7 @@ get_admin_password(char* username)
 
    for (int i = 0; i < config->number_of_admins; i++)
    {
-      if (!strcmp(&config->admins[i].username[0], username))
+      if (pgagroal_strcmp(&config->admins[i].username[0], username))
       {
          return &config->admins[i].password[0];
       }
@@ -3622,7 +3622,7 @@ pgagroal_user_known(char* user)
 
    for (int i = 0; i < config->number_of_users; i++)
    {
-      if (!strcmp(user, config->users[i].username))
+      if (pgagroal_strcmp(user, config->users[i].username))
       {
          return true;
       }
@@ -4637,10 +4637,10 @@ is_tls_user(char* username, char* database)
 
    for (int i = 0; i < config->number_of_hbas; i++)
    {
-      if ((!strcmp(database, config->hbas[i].database) || !strcmp("all", config->hbas[i].database)) &&
-          (!strcmp(username, config->hbas[i].username) || !strcmp("all", config->hbas[i].username)))
+      if ((pgagroal_strcmp(database, config->hbas[i].database) || pgagroal_strcmp("all", config->hbas[i].database)) &&
+          (pgagroal_strcmp(username, config->hbas[i].username) || pgagroal_strcmp("all", config->hbas[i].username)))
       {
-         if (!strcmp("hostssl", config->hbas[i].type))
+         if (pgagroal_strcmp("hostssl", config->hbas[i].type))
          {
             return true;
          }
@@ -5387,7 +5387,7 @@ retry:
    base64_stored_key = strtok(s2, ":");
    base64_server_key = strtok(NULL, ":");
 
-   if (strcmp("SCRAM-SHA-256", scram256) != 0)
+   if (!pgagroal_strcmp("SCRAM-SHA-256", scram256))
    {
       goto error;
    }
@@ -6018,7 +6018,7 @@ pgagroal_is_cert_authorized(const char* cert_identity, const char* requested_use
    // Exact case-sensitive comparison
    // For certificate authentication, we enforce exact match (case-sensitive)
    // to maintain maximum security and avoid ambiguity
-   if (strcmp(cert_identity, requested_username) == 0)
+   if (pgagroal_strcmp(cert_identity, requested_username))
    {
       pgagroal_log_debug("pgagroal_is_cert_authorized: Identity '%s' matches requested user '%s'",
                          cert_identity, requested_username);
@@ -6038,14 +6038,14 @@ resolve_database_alias(char* username, char* database)
    // Find the best rule for this user/database combination
    for (int i = 0; i < config->number_of_limits; i++)
    {
-      bool username_match = (!strcmp("all", config->limits[i].username) || !strcmp(username, config->limits[i].username));
+      bool username_match = (pgagroal_strcmp("all", config->limits[i].username) || pgagroal_strcmp(username, config->limits[i].username));
 
       if (username_match)
       {
          // Check if database matches any alias for this limit entry
          for (int j = 0; j < config->limits[i].aliases_count; j++)
          {
-            if (!strcmp(database, config->limits[i].aliases[j]))
+            if (pgagroal_strcmp(database, config->limits[i].aliases[j]))
             {
                pgagroal_log_debug("resolve_database_alias: '%s' -> '%s' (rule %d)",
                                   database, config->limits[i].database, i);

--- a/src/libpgagroal/server.c
+++ b/src/libpgagroal/server.c
@@ -247,7 +247,7 @@ pgagroal_check_server_identifiers(bool strict)
          {
             continue;
          }
-         if (!strcmp(identifiers[i], identifiers[j]))
+         if (pgagroal_strcmp(identifiers[i], identifiers[j]))
          {
             if (strict)
             {
@@ -1057,7 +1057,7 @@ pgagroal_server_clear(char* server)
 
    FOREACH_VALID_SERVER
    {
-      if (!strcmp(config->servers[i].name, server))
+      if (pgagroal_strcmp(config->servers[i].name, server))
       {
          state = atomic_load(&config->servers[i].state);
 
@@ -1098,7 +1098,7 @@ pgagroal_server_switch(char* server)
    // Find target server by name
    FOREACH_VALID_SERVER
    {
-      if (!strcmp(config->servers[i].name, server))
+      if (pgagroal_strcmp(config->servers[i].name, server))
       {
          new_primary = i;
          break;
@@ -1339,7 +1339,7 @@ process_server_parameters(int server, struct deque* server_parameters)
       pgagroal_log_trace("%s/process server_parameter '%s'", config->servers[server].name, iter->tag);
       char* value = pgagroal_value_to_string(iter->value, FORMAT_TEXT, NULL, 0);
       free(value);
-      if (!strcmp("server_version", iter->tag))
+      if (pgagroal_strcmp("server_version", iter->tag))
       {
          char* server_version = pgagroal_value_to_string(iter->value, FORMAT_TEXT, NULL, 0);
          if (sscanf(server_version, "%d.%d", &major, &minor) == 2)

--- a/src/libpgagroal/status.c
+++ b/src/libpgagroal/status.c
@@ -218,7 +218,7 @@ status_details(bool details, struct json* response)
 
       pgagroal_server_get_connectivity_info(i, &srv_status, &srv_primary, &behind_bytes);
 
-      if (pgagroal_compare_string(srv_primary, "Yes"))
+      if (pgagroal_strcmp(srv_primary, "Yes"))
       {
          number_of_primary++;
       }
@@ -238,7 +238,7 @@ status_details(bool details, struct json* response)
 
       pgagroal_json_put(servers, config->servers[i].name, (uintptr_t)js, ValueJSON);
 
-      if (srv_primary != NULL && pgagroal_compare_string(srv_primary, "No"))
+      if (srv_primary != NULL && pgagroal_strcmp(srv_primary, "No"))
       {
          char rep_status[64] = {0};
          char slot_name[64] = {0};
@@ -254,7 +254,7 @@ status_details(bool details, struct json* response)
          pgagroal_json_create(&standby_js);
          if (wal_result == 0)
          {
-            bool is_streaming = pgagroal_compare_string(rep_status, "streaming");
+            bool is_streaming = pgagroal_strcmp(rep_status, "streaming");
             pgagroal_json_put(standby_js, MANAGEMENT_ARGUMENT_STREAMING, (uintptr_t)is_streaming, ValueBool);
             pgagroal_json_put(standby_js, MANAGEMENT_ARGUMENT_WAL_RECEIVER_STATUS, (uintptr_t)rep_status, ValueString);
             pgagroal_json_put(standby_js, MANAGEMENT_ARGUMENT_SLOT_NAME, (uintptr_t)slot_name, ValueString);

--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -120,7 +120,7 @@ pgagroal_extract_username_database(struct message* msg, char** username, char** 
 
    for (int i = 0; i < counter; i++)
    {
-      if (!strcmp(array[i], "user"))
+      if (pgagroal_strcmp(array[i], "user"))
       {
          size = strlen(array[i + 1]) + 1;
          un = calloc(1, size);
@@ -128,7 +128,7 @@ pgagroal_extract_username_database(struct message* msg, char** username, char** 
 
          *username = un;
       }
-      else if (!strcmp(array[i], "database"))
+      else if (pgagroal_strcmp(array[i], "database"))
       {
          size = strlen(array[i + 1]) + 1;
          db = calloc(1, size);
@@ -136,7 +136,7 @@ pgagroal_extract_username_database(struct message* msg, char** username, char** 
 
          *database = db;
       }
-      else if (!strcmp(array[i], "application_name"))
+      else if (pgagroal_strcmp(array[i], "application_name"))
       {
          size = strlen(array[i + 1]) + 1;
          an = calloc(1, size);
@@ -875,7 +875,7 @@ pgagroal_ends_with(char* str, char* suffix)
    int str_len = strlen(str);
    int suffix_len = strlen(suffix);
 
-   return (str_len >= suffix_len) && (strcmp(str + (str_len - suffix_len), suffix) == 0);
+   return (str_len >= suffix_len) && (pgagroal_strcmp(str + (str_len - suffix_len), suffix));
 }
 
 char*
@@ -1128,7 +1128,7 @@ pgagroal_backtrace(void)
          }
 
          buffer[strlen(buffer) - 1] = '\0'; // Remove trailing newline
-         if (strcmp(buffer, "main") == 0)
+         if (pgagroal_strcmp(buffer, "main"))
          {
             found_main = true;
          }
@@ -1354,7 +1354,7 @@ pgagroal_indent(char* str, char* tag, int indent)
 }
 
 bool
-pgagroal_compare_string(const char* str1, const char* str2)
+pgagroal_strcmp(const char* str1, const char* str2)
 {
    if (str1 == NULL && str2 == NULL)
    {
@@ -1365,6 +1365,22 @@ pgagroal_compare_string(const char* str1, const char* str2)
       return false;
    }
    return strcmp(str1, str2) == 0;
+}
+
+bool
+pgagroal_strcasecmp(const char* str1, const char* str2)
+{
+   if (str1 == NULL && str2 == NULL)
+   {
+      return true;
+   }
+
+   if ((str1 == NULL && str2 != NULL) || (str1 != NULL && str2 == NULL))
+   {
+      return false;
+   }
+
+   return strcasecmp(str1, str2) == 0;
 }
 
 char*
@@ -2279,7 +2295,7 @@ pgagroal_is_username_reserved(char* username)
 
    for (i = 0; i < count; i++)
    {
-      if (pgagroal_compare_string(username, restricted_usernames[i]))
+      if (pgagroal_strcmp(username, restricted_usernames[i]))
       {
          return true;
       }
@@ -2304,7 +2320,7 @@ pgagroal_is_database_reserved(char* database)
 
    for (i = 0; i < count; i++)
    {
-      if (pgagroal_compare_string(database, restricted_databases[i]))
+      if (pgagroal_strcmp(database, restricted_databases[i]))
       {
          return true;
       }

--- a/src/main.c
+++ b/src/main.c
@@ -532,7 +532,7 @@ main(int argc, char** argv)
 
    if (directory_path != NULL)
    {
-      if (!strcmp(directory_path, PGAGROAL_DEFAULT_CONFIGURATION_PATH))
+      if (pgagroal_strcmp(directory_path, PGAGROAL_DEFAULT_CONFIGURATION_PATH))
       {
          pgagroal_log_warn("Using the default configuration directory %s, -D can be omitted.", directory_path);
       }
@@ -1756,7 +1756,7 @@ accept_mgt_cb(struct io_watcher* watcher)
       pgagroal_management_create_response(payload, -1, &res);
       pgagroal_json_create(&databases);
 
-      if (!strcmp("all", database))
+      if (pgagroal_strcmp("all", database))
       {
          struct json* js = NULL;
 
@@ -1777,7 +1777,7 @@ accept_mgt_cb(struct io_watcher* watcher)
          {
             struct json* js = NULL;
 
-            if (!strcmp(config->disabled[i], database))
+            if (pgagroal_strcmp(config->disabled[i], database))
             {
                memset(&config->disabled[i], 0, MAX_DATABASE_LENGTH);
 
@@ -1819,7 +1819,7 @@ accept_mgt_cb(struct io_watcher* watcher)
 
       config->all_disabled = false;
 
-      if (!strcmp("*", database) || !strcmp("all", database))
+      if (pgagroal_strcmp("*", database) || pgagroal_strcmp("all", database))
       {
          struct json* js = NULL;
 
@@ -2245,7 +2245,7 @@ accept_mgt_cb(struct io_watcher* watcher)
 
       for (int i = 0; index == -1 && i < config->number_of_frontend_users; i++)
       {
-         if (!strcmp(&config->frontend_users[i].username[0], username))
+         if (pgagroal_strcmp(&config->frontend_users[i].username[0], username))
          {
             index = i;
          }
@@ -3090,7 +3090,7 @@ arm_flush_timeout(int64_t seconds, const char* database)
    }
    for (int i = 0; i < NUMBER_OF_LIMITS; i++)
    {
-      if (flush_timeouts[i].in_use && !strcmp(flush_timeouts[i].database, db))
+      if (flush_timeouts[i].in_use && pgagroal_strcmp(flush_timeouts[i].database, db))
       {
          slot = i;
          break;

--- a/src/vault.c
+++ b/src/vault.c
@@ -149,10 +149,10 @@ router(SSL* c_ssl, SSL* s_ssl, int client_fd)
    }
 
    // Parse URL parameters for GET requests only
-   if (strcmp(method, "GET") == 0)
+   if (pgagroal_strcmp(method, "GET"))
    {
       // Call the appropriate handler function for the URL path
-      if (strncmp(path, "/users/", 7) == 0 && strcmp(method, "GET") == 0) // Only one '/'
+      if (strncmp(path, "/users/", 7) == 0 && pgagroal_strcmp(method, "GET")) // Only one '/'
       {
          // Extract the username from the path
          sscanf(path, "/users/%128s", username);
@@ -192,7 +192,7 @@ router(SSL* c_ssl, SSL* s_ssl, int client_fd)
          // Call the appropriate handler function with the username
          route_users(username, &response, s_ssl, client_fd);
       }
-      else if (strncmp(path, "/status", 7) == 0 && strcmp(method, "GET") == 0)
+      else if (strncmp(path, "/status", 7) == 0 && pgagroal_strcmp(method, "GET"))
       {
          pgagroal_log_debug("router: Processing status endpoint request");
          route_status(&response);

--- a/test/include/mctf.h
+++ b/test/include/mctf.h
@@ -39,6 +39,7 @@ extern "C" {
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <utils.h>
 
 /* Special error codes */
 #define MCTF_CODE_SKIPPED (-1)
@@ -273,45 +274,12 @@ mctf_format_error(const char* format, ...);
    while (0)
 
 /* String assertion macros */
-#define MCTF_ASSERT_STR_EQ(actual, expected, error_label, ...)                     \
-   do                                                                              \
-   {                                                                               \
-      const char* _actual = (actual);                                              \
-      const char* _expected = (expected);                                          \
-      if (_actual == NULL || _expected == NULL || strcmp(_actual, _expected) != 0) \
-      {                                                                            \
-         mctf_errno = __LINE__;                                                    \
-         if (sizeof(#__VA_ARGS__) > 1)                                             \
-         {                                                                         \
-            mctf_errmsg = mctf_format_error(__VA_ARGS__);                          \
-         }                                                                         \
-         else                                                                      \
-         {                                                                         \
-            mctf_errmsg = mctf_format_error("Expected '%s', got '%s'",             \
-                                            _expected ? _expected : "NULL",        \
-                                            _actual ? _actual : "NULL");           \
-         }                                                                         \
-         goto error_label;                                                         \
-      }                                                                            \
-   }                                                                               \
-   while (0)
-
-/* String inequality assertion macro */
-#define MCTF_ASSERT_STR_NEQ(actual, expected, error_label, ...)                         \
+#define MCTF_ASSERT_STR_EQ(actual, expected, error_label, ...)                          \
    do                                                                                   \
    {                                                                                    \
       const char* _actual = (actual);                                                   \
       const char* _expected = (expected);                                               \
-      bool _equal = false;                                                              \
-      if (_actual == NULL && _expected == NULL)                                         \
-      {                                                                                 \
-         _equal = true;                                                                 \
-      }                                                                                 \
-      else if (_actual != NULL && _expected != NULL && strcmp(_actual, _expected) == 0) \
-      {                                                                                 \
-         _equal = true;                                                                 \
-      }                                                                                 \
-      if (_equal)                                                                       \
+      if (_actual == NULL || _expected == NULL || !pgagroal_strcmp(_actual, _expected)) \
       {                                                                                 \
          mctf_errno = __LINE__;                                                         \
          if (sizeof(#__VA_ARGS__) > 1)                                                  \
@@ -320,13 +288,46 @@ mctf_format_error(const char* format, ...);
          }                                                                              \
          else                                                                           \
          {                                                                              \
-            mctf_errmsg = mctf_format_error("Expected '%s' to be different from '%s'",  \
-                                            _actual ? _actual : "NULL",                 \
-                                            _expected ? _expected : "NULL");            \
+            mctf_errmsg = mctf_format_error("Expected '%s', got '%s'",                  \
+                                            _expected ? _expected : "NULL",             \
+                                            _actual ? _actual : "NULL");                \
          }                                                                              \
          goto error_label;                                                              \
       }                                                                                 \
    }                                                                                    \
+   while (0)
+
+/* String inequality assertion macro */
+#define MCTF_ASSERT_STR_NEQ(actual, expected, error_label, ...)                             \
+   do                                                                                       \
+   {                                                                                        \
+      const char* _actual = (actual);                                                       \
+      const char* _expected = (expected);                                                   \
+      bool _equal = false;                                                                  \
+      if (_actual == NULL && _expected == NULL)                                             \
+      {                                                                                     \
+         _equal = true;                                                                     \
+      }                                                                                     \
+      else if (_actual != NULL && _expected != NULL && pgagroal_strcmp(_actual, _expected)) \
+      {                                                                                     \
+         _equal = true;                                                                     \
+      }                                                                                     \
+      if (_equal)                                                                           \
+      {                                                                                     \
+         mctf_errno = __LINE__;                                                             \
+         if (sizeof(#__VA_ARGS__) > 1)                                                      \
+         {                                                                                  \
+            mctf_errmsg = mctf_format_error(__VA_ARGS__);                                   \
+         }                                                                                  \
+         else                                                                               \
+         {                                                                                  \
+            mctf_errmsg = mctf_format_error("Expected '%s' to be different from '%s'",      \
+                                            _actual ? _actual : "NULL",                     \
+                                            _expected ? _expected : "NULL");                \
+         }                                                                                  \
+         goto error_label;                                                                  \
+      }                                                                                     \
+   }                                                                                        \
    while (0)
 
 /* Float assertion macros */

--- a/test/libpgagroaltest/mctf.c
+++ b/test/libpgagroaltest/mctf.c
@@ -181,7 +181,7 @@ mctf_extract_module_name(const char* file_path)
 
    /* Remove ".c" suffix if present */
    size_t len = strlen(basename);
-   if (len > 2 && strcmp(basename + len - 2, ".c") == 0)
+   if (len > 2 && pgagroal_strcmp(basename + len - 2, ".c"))
    {
       len -= 2;
    }
@@ -441,7 +441,7 @@ mctf_run_tests(mctf_filter_type_t filter_type, const char* filter)
          continue;
       }
 
-      if (!current_module || strcmp(current_module, test->module) != 0)
+      if (!current_module || !pgagroal_strcmp(current_module, test->module))
       {
          if (current_module)
          {

--- a/test/testcases/test_art.c
+++ b/test/testcases/test_art.c
@@ -308,32 +308,32 @@ MCTF_TEST(test_art_iterator_read)
    int cnt = 0;
    while (pgagroal_art_iterator_next(iter))
    {
-      if (pgagroal_compare_string(iter->key, "key_str"))
+      if (pgagroal_strcmp(iter->key, "key_str"))
       {
          MCTF_ASSERT_STR_EQ((char*)pgagroal_value_data(iter->value), "value1", cleanup, "key_str value should be value1");
       }
-      else if (pgagroal_compare_string(iter->key, "key_int"))
+      else if (pgagroal_strcmp(iter->key, "key_int"))
       {
          MCTF_ASSERT_INT_EQ((int)pgagroal_value_data(iter->value), 1, cleanup, "key_int value should be 1");
       }
-      else if (pgagroal_compare_string(iter->key, "key_bool"))
+      else if (pgagroal_strcmp(iter->key, "key_bool"))
       {
          MCTF_ASSERT((bool)pgagroal_value_data(iter->value), cleanup, "key_bool value should be true");
       }
-      else if (pgagroal_compare_string(iter->key, "key_float"))
+      else if (pgagroal_strcmp(iter->key, "key_float"))
       {
          MCTF_ASSERT_FLOAT_EQ(pgagroal_value_to_float(pgagroal_value_data(iter->value)), 2.5, cleanup, "key_float value should be 2.5");
       }
-      else if (pgagroal_compare_string(iter->key, "key_double"))
+      else if (pgagroal_strcmp(iter->key, "key_double"))
       {
          MCTF_ASSERT_DOUBLE_EQ(pgagroal_value_to_double(pgagroal_value_data(iter->value)), 2.5, cleanup, "key_double value should be 2.5");
       }
-      else if (pgagroal_compare_string(iter->key, "key_mem"))
+      else if (pgagroal_strcmp(iter->key, "key_mem"))
       {
          // as long as it exists...
          MCTF_ASSERT(true, cleanup, "key_mem should exist");
       }
-      else if (pgagroal_compare_string(iter->key, "key_obj"))
+      else if (pgagroal_strcmp(iter->key, "key_obj"))
       {
          MCTF_ASSERT_INT_EQ(((struct art_test_obj*)pgagroal_value_data(iter->value))->idx, 1, cleanup, "key_obj idx should be 1");
          MCTF_ASSERT_STR_EQ(((struct art_test_obj*)pgagroal_value_data(iter->value))->str, "obj1", cleanup, "key_obj str should be obj1");
@@ -384,42 +384,42 @@ MCTF_TEST(test_art_iterator_remove)
    while (pgagroal_art_iterator_next(iter))
    {
       cnt++;
-      if (pgagroal_compare_string(iter->key, "key_str"))
+      if (pgagroal_strcmp(iter->key, "key_str"))
       {
          MCTF_ASSERT_STR_EQ((char*)pgagroal_value_data(iter->value), "value1", cleanup, "key_str value should be value1");
          pgagroal_art_iterator_remove(iter);
          MCTF_ASSERT(!pgagroal_art_contains_key(t, "key_str"), cleanup, "key_str should not be contained");
       }
-      else if (pgagroal_compare_string(iter->key, "key_int"))
+      else if (pgagroal_strcmp(iter->key, "key_int"))
       {
          MCTF_ASSERT_INT_EQ((int)pgagroal_value_data(iter->value), 1, cleanup, "key_int value should be 1");
          pgagroal_art_iterator_remove(iter);
          MCTF_ASSERT(!pgagroal_art_contains_key(t, "key_int"), cleanup, "key_int should not be contained");
       }
-      else if (pgagroal_compare_string(iter->key, "key_bool"))
+      else if (pgagroal_strcmp(iter->key, "key_bool"))
       {
          MCTF_ASSERT((bool)pgagroal_value_data(iter->value), cleanup, "key_bool value should be true");
          pgagroal_art_iterator_remove(iter);
          MCTF_ASSERT(!pgagroal_art_contains_key(t, "key_bool"), cleanup, "key_bool should not be contained");
       }
-      else if (pgagroal_compare_string(iter->key, "key_float"))
+      else if (pgagroal_strcmp(iter->key, "key_float"))
       {
          MCTF_ASSERT_FLOAT_EQ(pgagroal_value_to_float(pgagroal_value_data(iter->value)), 2.5, cleanup, "key_float value should be 2.5");
          pgagroal_art_iterator_remove(iter);
          MCTF_ASSERT(!pgagroal_art_contains_key(t, "key_float"), cleanup, "key_float should not be contained");
       }
-      else if (pgagroal_compare_string(iter->key, "key_double"))
+      else if (pgagroal_strcmp(iter->key, "key_double"))
       {
          MCTF_ASSERT_DOUBLE_EQ(pgagroal_value_to_double(pgagroal_value_data(iter->value)), 2.5, cleanup, "key_double value should be 2.5");
          pgagroal_art_iterator_remove(iter);
          MCTF_ASSERT(!pgagroal_art_contains_key(t, "key_double"), cleanup, "key_double should not be contained");
       }
-      else if (pgagroal_compare_string(iter->key, "key_mem"))
+      else if (pgagroal_strcmp(iter->key, "key_mem"))
       {
          pgagroal_art_iterator_remove(iter);
          MCTF_ASSERT(!pgagroal_art_contains_key(t, "key_mem"), cleanup, "key_mem should not be contained");
       }
-      else if (pgagroal_compare_string(iter->key, "key_obj"))
+      else if (pgagroal_strcmp(iter->key, "key_obj"))
       {
          MCTF_ASSERT_INT_EQ(((struct art_test_obj*)pgagroal_value_data(iter->value))->idx, 1, cleanup, "key_obj idx should be 1");
          MCTF_ASSERT_STR_EQ(((struct art_test_obj*)pgagroal_value_data(iter->value))->str, "obj1", cleanup, "key_obj str should be obj1");

--- a/test/testcases/test_message_complete.c
+++ b/test/testcases/test_message_complete.c
@@ -251,7 +251,7 @@ MCTF_TEST(test_scram256_plus_client_first)
    MCTF_ASSERT(data[0] == 'p', cleanup, "first byte must be 'p'");
    MCTF_ASSERT_INT_EQ(pgagroal_read_int32(data + 1), (int)(msg->length - 1), cleanup,
                       "declared length excludes the tag byte");
-   MCTF_ASSERT(strcmp(data + 5, "SCRAM-SHA-256-PLUS") == 0, cleanup,
+   MCTF_ASSERT(pgagroal_strcmp(data + 5, "SCRAM-SHA-256-PLUS"), cleanup,
                "mechanism must be SCRAM-SHA-256-PLUS");
    MCTF_ASSERT_INT_EQ(pgagroal_read_int32(data + 24), (int)(strlen(initial) + strlen(nounce)), cleanup,
                       "initial-response length must cover gs2 header + bare");

--- a/test/testcases/test_pool_saturation.c
+++ b/test/testcases/test_pool_saturation.c
@@ -160,8 +160,8 @@ MCTF_TEST(test_pgagroal_pool_max_size_cap)
 
    for (int i = 0; i < config->number_of_limits; i++)
    {
-      if (!strcmp((const char*)config->limits[i].username, user) &&
-          !strcmp((const char*)config->limits[i].database, database))
+      if (pgagroal_strcmp((const char*)config->limits[i].username, user) &&
+          pgagroal_strcmp((const char*)config->limits[i].database, database))
       {
          max_size = config->limits[i].max_size;
          found_rule = 1;

--- a/test/testcases/test_utils.c
+++ b/test/testcases/test_utils.c
@@ -91,15 +91,32 @@ cleanup:
 
 MCTF_TEST(test_utils_compare_string)
 {
-   MCTF_ASSERT(pgagroal_compare_string(NULL, NULL), cleanup,
+   MCTF_ASSERT(pgagroal_strcmp(NULL, NULL), cleanup,
                "two NULLs should compare equal");
-   MCTF_ASSERT(!pgagroal_compare_string("a", NULL), cleanup,
+   MCTF_ASSERT(!pgagroal_strcmp("a", NULL), cleanup,
                "non-NULL vs NULL should differ");
-   MCTF_ASSERT(!pgagroal_compare_string(NULL, "a"), cleanup,
+   MCTF_ASSERT(!pgagroal_strcmp(NULL, "a"), cleanup,
                "NULL vs non-NULL should differ");
-   MCTF_ASSERT(pgagroal_compare_string("same", "same"), cleanup,
+   MCTF_ASSERT(pgagroal_strcmp("same", "same"), cleanup,
                "identical strings should compare equal");
-   MCTF_ASSERT(!pgagroal_compare_string("a", "b"), cleanup,
+   MCTF_ASSERT(!pgagroal_strcmp("a", "b"), cleanup,
+               "different strings should not compare equal");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_utils_insensitive_compare_string)
+{
+   MCTF_ASSERT(pgagroal_strcasecmp(NULL, NULL), cleanup,
+               "two NULLs should compare equal");
+   MCTF_ASSERT(!pgagroal_strcasecmp("a", NULL), cleanup,
+               "non-NULL vs NULL should differ");
+   MCTF_ASSERT(!pgagroal_strcasecmp(NULL, "a"), cleanup,
+               "NULL vs non-NULL should differ");
+   MCTF_ASSERT(pgagroal_strcasecmp("Same", "same"), cleanup,
+               "same strings with different case should compare equal");
+   MCTF_ASSERT(!pgagroal_strcasecmp("a", "b"), cleanup,
                "different strings should not compare equal");
 
 cleanup:


### PR DESCRIPTION
###  **Description**

Due to mixing and matching pgagroal_compare_string and strcmp :
- Renames `pgagroal_compare_string` to `pgagroal_strcmp`.
- Replaces `strcmp` equality checks with `pgagroal_strcmp` across the repository.
- Adds `pgagroal_strcasecmp` for case-insensitive string comparisons.
- Replaces `strcasecmp` usage with `pgagroal_strcasecmp` where appropriate.

### **Testing**

- Build completed successfully.
- Test suite: 143 passed, 0 failed, 1 skipped.
- The skipped test requires the metrics endpoint to be enabled and is unrelated to this change.