### PR TITLE
Fix fd for anonymous mmap fallback

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,3 +45,4 @@ R Sai Pranav <rajasaipranav0@gmail.com>
 Esraa Yehia <yehiae996@gmail.com>
 Yousuf Mahmoud <yusufmahmoud.dev@gmail.com>
 Youssef Sherief <youssefsherief2718@gmail.com>
+Abdulrahman Nader <a0xnader.oss@outlook.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -53,6 +53,7 @@ R Sai Pranav <rajasaipranav0@gmail.com>
 Esraa Yehia <yehiae996@gmail.com>
 Yousuf Mahmoud <yusufmahmoud.dev@gmail.com>
 Youssef Sherief <youssefsherief2718@gmail.com>
+Abdulrahman Nader <a0xnader.oss@outlook.com>
 ```
 
 ## Committers

--- a/src/libpgagroal/shmem.c
+++ b/src/libpgagroal/shmem.c
@@ -72,7 +72,7 @@ pgagroal_create_shared_memory(size_t size, unsigned char hp, void** shmem)
    if (s == NULL)
    {
       visibility = MAP_ANONYMOUS | MAP_SHARED;
-      s = mmap(NULL, size, protection, visibility, 0, 0);
+      s = mmap(NULL, size, protection, visibility, -1, 0);
 
       if (s == (void*)-1)
       {


### PR DESCRIPTION
Use -1 instead of 0 as fd for the fallback anonymous mmap() in pgagroal_create_shared_memory() to match the initial call and fix portability on FreeBSD and OpenBSD which require -1 for MAP_ANONYMOUS. Update AUTHORS.

Close #1043
