### PR TITLE
[#1045] Add missing dependencies to CONTRIBUTING.md

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,3 +44,4 @@ Finn Rayk Gartner <finn.gartner@canonical.com>
 R Sai Pranav <rajasaipranav0@gmail.com>
 Esraa Yehia <yehiae996@gmail.com>
 Yousuf Mahmoud <yusufmahmoud.dev@gmail.com>
+Youssef Sherief <youssefsherief2718@gmail.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Don't forget to indicate your pgagroal version.
 You can use the follow command, if you are using a [Fedora](https://getfedora.org/) based platform:
 
 ```
-dnf install git gcc cmake make liburing liburing-devel openssl openssl-devel systemd systemd-devel python3-docutils libasan libasan-static binutils clang clang-analyzer clang-tools-extra
+dnf install git gcc cmake make liburing liburing-devel openssl openssl-devel systemd systemd-devel python3-docutils libatomic zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel bzip2 bzip2-devel libasan libasan-static binutils clang clang-analyzer clang-tools-extra
 ```
 
 in order to get the necessary dependencies.

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -52,6 +52,7 @@ Finn Rayk Gartner <finn.gartner@canonical.com>
 R Sai Pranav <rajasaipranav0@gmail.com>
 Esraa Yehia <yehiae996@gmail.com>
 Yousuf Mahmoud <yusufmahmoud.dev@gmail.com>
+Youssef Sherief <youssefsherief2718@gmail.com>
 ```
 
 ## Committers


### PR DESCRIPTION
Added `libatomic`, `zlib`, `zlib-devel`, `libzstd`, `libzstd-devel`, `lz4`, `lz4-devel`, `bzip2`, and `bzip2-devel` to `CONTRIBUTING.md` to match `DEVELOPERS.md` and satisfy the build requirements in `CMakeLists.txt`.

Closes [#1045](https://github.com/pgagroal/pgagroal/issues/1045).