### PR TITLE
security: fix is_allowed_address overflows, atoi and IPv6 mask

### DIFF
--- a/src/include/security.h
+++ b/src/include/security.h
@@ -115,6 +115,9 @@ pgagroal_get_user_password(char* username);
 bool
 pgagroal_user_known(char* user);
 
+bool
+pgagroal_is_allowed_address(char* address, char* entry);
+
 /**
  * Is the TLS configuration valid
  * @return 0 upon success, otherwise 1

--- a/src/libpgagroal/security.c
+++ b/src/libpgagroal/security.c
@@ -97,7 +97,7 @@ static int server_scram256(char* username, char* password, int slot, SSL* server
 static bool is_allowed(char* username, char* database, char* address, int* hba_method);
 static bool is_allowed_username(char* username, char* entry);
 static bool is_allowed_database(char* database, char* entry);
-static bool is_allowed_address(char* address, char* entry);
+bool pgagroal_is_allowed_address(char* address, char* entry);
 static bool is_disabled(char* database);
 
 static int get_hba_method(int index);
@@ -3177,7 +3177,7 @@ is_allowed(char* username, char* database, char* address, int* hba_method)
 
    for (int i = 0; i < config->number_of_hbas; i++)
    {
-      if (is_allowed_address(address, config->hbas[i].address) &&
+      if (pgagroal_is_allowed_address(address, config->hbas[i].address) &&
           is_allowed_database(database, config->hbas[i].database) &&
           is_allowed_username(username, config->hbas[i].username))
       {
@@ -3231,8 +3231,8 @@ is_allowed_database(char* database, char* entry)
    return false;
 }
 
-static bool
-is_allowed_address(char* address, char* entry)
+bool
+pgagroal_is_allowed_address(char* address, char* entry)
 {
    struct sockaddr_in address_sa4;
    struct sockaddr_in6 address_sa6;
@@ -3240,6 +3240,7 @@ is_allowed_address(char* address, char* entry)
    struct sockaddr_in6 entry_sa6;
    char addr[INET6_ADDRSTRLEN];
    char s_mask[4];
+   size_t n;
    int mask;
    char* marker;
    bool ipv4 = true;
@@ -3259,10 +3260,36 @@ is_allowed_address(char* address, char* entry)
       return false;
    }
 
-   memcpy(&addr, entry, marker - entry);
+   n = marker - entry;
+   if (n >= sizeof(addr))
+   {
+      pgagroal_log_warn("Invalid HBA entry: %s", entry);
+      return false;
+   }
+
+   memcpy(&addr, entry, n);
+   addr[n] = '\0';
    marker += sizeof(char);
-   memcpy(&s_mask, marker, strlen(marker));
-   mask = atoi(s_mask);
+   n = strlen(marker);
+   if (n >= sizeof(s_mask) || n == 0)
+   {
+      pgagroal_log_warn("Invalid HBA entry: %s", entry);
+      return false;
+   }
+
+   memcpy(s_mask, marker, n);
+   s_mask[n] = '\0';
+
+   {
+      char* endptr = NULL;
+      long val = strtol(s_mask, &endptr, 10);
+      if (endptr == s_mask || *endptr != '\0')
+      {
+         pgagroal_log_warn("Invalid HBA entry: %s", entry);
+         return false;
+      }
+      mask = (int)val;
+   }
 
    if (strchr(addr, ':') == NULL)
    {
@@ -3347,7 +3374,6 @@ is_allowed_address(char* address, char* entry)
       }
 
       struct sockaddr_in6 netmask;
-      bool result = false;
 
       memset(&netmask, 0, sizeof(struct sockaddr_in6));
 
@@ -3358,10 +3384,13 @@ is_allowed_address(char* address, char* entry)
 
       for (unsigned i = 0; i < 16; i++)
       {
-         result |= (0 != (address_sa6.sin6_addr.s6_addr[i] & !netmask.sin6_addr.s6_addr[i]));
+         if ((address_sa6.sin6_addr.s6_addr[i] & netmask.sin6_addr.s6_addr[i]) !=
+             (entry_sa6.sin6_addr.s6_addr[i] & netmask.sin6_addr.s6_addr[i]))
+         {
+            return false;
+         }
       }
-
-      return result;
+      return true;
    }
 
    return false;

--- a/test/testcases/test_hba.c
+++ b/test/testcases/test_hba.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 The pgagroal community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <security.h>
+#include <mctf.h>
+
+MCTF_TEST(test_hba_invalid_masks)
+{
+   MCTF_ASSERT(!pgagroal_is_allowed_address("127.0.0.1", "127.0.0.0/abc"), cleanup, "abc should deny");
+   MCTF_ASSERT(!pgagroal_is_allowed_address("127.0.0.1", "192.168.1.0/1000"), cleanup, "1000 should deny");
+   MCTF_ASSERT(!pgagroal_is_allowed_address("127.0.0.1", "192.168.1.0/24abc"), cleanup, "24abc should deny");
+   MCTF_ASSERT(!pgagroal_is_allowed_address("127.0.0.1", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/24"), cleanup, "long addr should deny");
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_hba_ipv6)
+{
+   MCTF_ASSERT(pgagroal_is_allowed_address("2001:db8::1", "2001:db8::/64"), cleanup, "2001:db8::1 in /64 should allow");
+   MCTF_ASSERT(pgagroal_is_allowed_address("2001:db8::2", "2001:db8::/64"), cleanup, "2001:db8::2 in /64 should allow");
+   MCTF_ASSERT(!pgagroal_is_allowed_address("::1", "2001:db8::/64"), cleanup, "::1 not in 2001:db8::/64 should deny");
+   MCTF_ASSERT(!pgagroal_is_allowed_address("2001:abcd::1", "2001:db8::/64"), cleanup, "2001:abcd not in 2001:db8 should deny");
+cleanup:
+   MCTF_FINISH();
+}


### PR DESCRIPTION
Fixes #1047

`is_allowed_address()` had 4 bugs:

- `s_mask[4]`/`addr[46]`: `memcpy` without bounds check or `\0` terminator —
  ASan reports `WRITE of size 50` / `READ of size 5`
- `atoi` accepts `"abc"→0`, `"24abc"→24` — `127.0.0.0/abc` was allowed as
  `127.*` instead of being rejected as invalid
- IPv6: `entry_sa6` ignored in final comparison, `!netmask` (logical NOT)
  used instead of bitwise `& netmask`

Fix bounded copy (`n >= sizeof` check + `\0`), replace `atoi` with `strtol`
and `endptr` validation (logs `Invalid HBA entry` on bad input), correct IPv6
to compare `(address & netmask) == (entry & netmask)` per byte using
`entry_sa6`.

Tested with ASan (no overflow), `127.0.0.0/abc` correctly denied,
`2001:db8::1`/`2001:db8::2` both correctly allowed for `2001:db8::/64`,
`::1` correctly denied.