### PR TITLE
Add max and total client wait time metrics

### DIFF
--- a/contrib/grafana/README.md
+++ b/contrib/grafana/README.md
@@ -90,6 +90,8 @@ The dashboards visualize these pgagroal Prometheus metrics:
 - `pgagroal_client_wait` - Number of waiting clients
 - `pgagroal_client_active` - Number of active clients
 - `pgagroal_wait_time` - Client wait time
+- `pgagroal_max_wait_time` - Maximum client wait time
+- `pgagroal_total_wait_time` - Total accumulated client wait time
 
 ### Performance
 - `pgagroal_query_count` - Total query count

--- a/contrib/grafana/pgagroal-overview.json
+++ b/contrib/grafana/pgagroal-overview.json
@@ -1168,6 +1168,24 @@
                     "expr": "pgagroal_wait_time",
                     "instant": true,
                     "refId": "A"
+                },
+                {
+                    "datasource": {
+                       "type": "prometheus",
+                       "uid": "${DS_PROMETHEUS}"
+                    },
+                    "expr": "pgagroal_max_wait_time",
+                    "instant": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${DS_PROMETHEUS}"
+                    },
+                    "expr": "pgagroal_total_wait_time",
+                    "instant": true,
+                    "refId": "C"
                 }
             ],
             "title": "Wait Time",

--- a/contrib/prometheus_scrape/extra.info
+++ b/contrib/prometheus_scrape/extra.info
@@ -35,6 +35,12 @@ pgagroal_failed_servers
 pgagroal_wait_time
 + Measures the current waiting time in seconds for clients waiting for available connections from the pool.
 
+pgagroal_max_wait_time
++ Measures the maximum time in seconds that a client has waited for an available connection.
+
+pgagroal_total_wait_time
++ Measures the total accumulated client wait time in seconds.
+
 pgagroal_query_count
 + Tracks the total cumulative number of SQL queries that have been processed through pgagroal since startup.
 

--- a/doc/manual/en/11-prometheus.md
+++ b/doc/manual/en/11-prometheus.md
@@ -54,6 +54,14 @@ The number of failed servers
 
 The waiting time of clients
 
+**pgagroal_max_wait_time**
+
+The maximum time a client has waited for a connection
+
+**pgagroal_total_wait_time**
+
+The total accumulated client wait time
+
 **pgagroal_query_count**
 
 The number of queries

--- a/src/include/pgagroal.h
+++ b/src/include/pgagroal.h
@@ -627,8 +627,9 @@ struct main_prometheus
    atomic_ulong client_wait;      /**< The number of waiting clients */
    atomic_ulong client_active;    /**< The number of active clients */
    atomic_ulong client_wait_time; /**< The time the client waits */
-
-   atomic_ullong query_count; /**< The number of queries */
+   atomic_ulong client_max_wait_time;   /**< The maximum client wait time */
+   atomic_ulong client_total_wait_time; /**< The total client wait time */
+   atomic_ulong query_count; /**< The number of queries */
    atomic_ullong tx_count;    /**< The number of transactions */
 
    atomic_ullong network_sent;     /**< The bytes sent by clients */

--- a/src/include/prometheus.h
+++ b/src/include/prometheus.h
@@ -235,6 +235,17 @@ pgagroal_prometheus_client_wait_add(void);
  */
 void
 pgagroal_prometheus_client_wait_sub(void);
+/**
+ * Set the maximum client wait time
+ */
+void
+pgagroal_prometheus_client_max_wait_time_set(unsigned long wait_time);
+
+/**
+ * Add to the total client wait time
+ */
+void
+pgagroal_prometheus_client_total_wait_time_add(unsigned long wait_time);
 
 /**
  * Increase client_active by 1

--- a/src/libpgagroal/pool.c
+++ b/src/libpgagroal/pool.c
@@ -357,10 +357,13 @@ start:
 
       config->connections[*slot].timestamp = time(NULL);
 
-      if (config->common.metrics > 0)
-      {
-         atomic_store(&prometheus->client_wait_time, difftime(time(NULL), start_time));
-      }
+   if (config->common.metrics > 0)
+   {
+     unsigned long wait_time = (unsigned long)difftime(time(NULL), start_time);
+     atomic_store(&prometheus->client_wait_time, wait_time);
+     pgagroal_prometheus_client_total_wait_time_add(wait_time);
+     pgagroal_prometheus_client_max_wait_time_set(wait_time);
+   }
       pgagroal_prometheus_connection_success();
       pgagroal_tracking_event_slot(TRACKER_GET_CONNECTION_SUCCESS, *slot);
       pgagroal_prometheus_connection_unawaiting(best_rule);
@@ -435,7 +438,10 @@ retry2:
 timeout:
    if (config->common.metrics > 0)
    {
-      atomic_store(&prometheus->client_wait_time, difftime(time(NULL), start_time));
+    unsigned long wait_time = (unsigned long)difftime(time(NULL), start_time);
+    atomic_store(&prometheus->client_wait_time, wait_time);
+    pgagroal_prometheus_client_total_wait_time_add(wait_time);
+    pgagroal_prometheus_client_max_wait_time_set(wait_time);
    }
    pgagroal_prometheus_connection_timeout();
    pgagroal_tracking_event_basic(TRACKER_GET_CONNECTION_TIMEOUT, username, database);
@@ -450,7 +456,10 @@ error:
    atomic_fetch_sub(&config->active_connections, 1);
    if (config->common.metrics > 0)
    {
-      atomic_store(&prometheus->client_wait_time, difftime(time(NULL), start_time));
+   unsigned long wait_time = (unsigned long)difftime(time(NULL), start_time);
+   atomic_store(&prometheus->client_wait_time, wait_time);
+   pgagroal_prometheus_client_total_wait_time_add(wait_time);
+   pgagroal_prometheus_client_max_wait_time_set(wait_time);
    }
    pgagroal_prometheus_connection_error();
    pgagroal_prometheus_connection_unawaiting(best_rule);

--- a/src/libpgagroal/prometheus.c
+++ b/src/libpgagroal/prometheus.c
@@ -393,7 +393,8 @@ pgagroal_init_prometheus(size_t* p_size, void** p_shmem)
    atomic_init(&prometheus->client_wait, 0);
    atomic_init(&prometheus->client_active, 0);
    atomic_init(&prometheus->client_wait_time, 0);
-
+   atomic_init(&prometheus->client_max_wait_time, 0);
+  atomic_init(&prometheus->client_total_wait_time, 0);
    atomic_init(&prometheus->query_count, 0);
    atomic_init(&prometheus->tx_count, 0);
 
@@ -842,7 +843,43 @@ pgagroal_prometheus_client_wait_sub(void)
 
    atomic_fetch_sub(&prometheus->client_wait, 1);
 }
+/**
+ * Set the maximum client wait time
+ */
+void
+pgagroal_prometheus_client_max_wait_time_set(unsigned long wait_time)
+{
+   struct main_prometheus* prometheus;
+   unsigned long current;
 
+   if (!is_prometheus_enabled())
+   {
+      return;
+   }
+
+   prometheus = (struct main_prometheus*)prometheus_shmem;
+
+   current = atomic_load(&prometheus->client_max_wait_time);
+
+   while (wait_time > current &&!atomic_compare_exchange_weak(&prometheus->client_max_wait_time,&current,wait_time)){}
+}
+/**
+ * Add to the total client wait time
+ */
+void
+pgagroal_prometheus_client_total_wait_time_add(unsigned long wait_time)
+{
+   struct main_prometheus* prometheus;
+
+   if (!is_prometheus_enabled())
+   {
+      return;
+   }
+
+   prometheus = (struct main_prometheus*)prometheus_shmem;
+
+   atomic_fetch_add(&prometheus->client_total_wait_time, wait_time);
+}
 void
 pgagroal_prometheus_client_active_add(void)
 {
@@ -1077,7 +1114,8 @@ pgagroal_prometheus_clear(void)
    atomic_store(&prometheus->client_active, 0);
    atomic_store(&prometheus->client_wait, 0);
    atomic_store(&prometheus->client_wait_time, 0);
-
+   atomic_store(&prometheus->client_max_wait_time, 0);
+   atomic_store(&prometheus->client_total_wait_time, 0);
    atomic_store(&prometheus->query_count, 0);
    atomic_store(&prometheus->tx_count, 0);
 
@@ -1522,6 +1560,14 @@ home_page(SSL* client_ssl, int client_fd)
    data = pgagroal_append(data, "  <h2>pgagroal_wait_time</h2>\n");
    data = pgagroal_append(data, "  <p>\n");
    data = pgagroal_append(data, "   The waiting time of clients\n");
+   data = pgagroal_append(data, "  </p>\n");
+   data = pgagroal_append(data, "  <h2>pgagroal_max_wait_time</h2>\n");
+   data = pgagroal_append(data, "  <p>\n");
+   data = pgagroal_append(data, "   The maximum time a client has waited for a connection\n");
+   data = pgagroal_append(data, "  </p>\n");
+   data = pgagroal_append(data, "  <h2>pgagroal_total_wait_time</h2>\n");
+   data = pgagroal_append(data, "  <p>\n");
+   data = pgagroal_append(data, "   The total accumulated client wait time\n");
    data = pgagroal_append(data, "  </p>\n");
    data = pgagroal_append(data, "  <h2>pgagroal_query_count</h2>\n");
    data = pgagroal_append(data, "  <p>\n");
@@ -2549,6 +2595,24 @@ general_information(prometheus_metrics_container_t* container)
    data = pgagroal_append_ulong(data, atomic_load(&prometheus->client_wait_time));
    data = pgagroal_append(data, "\n");
    add_metric_to_art(container->general_metrics, "pgagroal_wait_time", data, NULL, NULL, 0);
+   free(data);
+   data = NULL;
+
+   data = pgagroal_append(data, "#HELP pgagroal_max_wait_time The maximum time a client has waited for a connection\n");
+   data = pgagroal_append(data, "#TYPE pgagroal_max_wait_time gauge\n");
+   data = pgagroal_append(data, "pgagroal_max_wait_time ");
+   data = pgagroal_append_ulong(data, atomic_load(&prometheus->client_max_wait_time));
+   data = pgagroal_append(data, "\n");
+   add_metric_to_art(container->general_metrics, "pgagroal_max_wait_time", data, NULL, NULL, 0);
+   free(data);
+   data = NULL;
+
+   data = pgagroal_append(data, "#HELP pgagroal_total_wait_time The total accumulated client wait time\n");
+   data = pgagroal_append(data, "#TYPE pgagroal_total_wait_time counter\n");
+   data = pgagroal_append(data, "pgagroal_total_wait_time ");
+   data = pgagroal_append_ulong(data, atomic_load(&prometheus->client_total_wait_time));
+   data = pgagroal_append(data, "\n");
+   add_metric_to_art(container->general_metrics, "pgagroal_total_wait_time", data, NULL, NULL, 0);
    free(data);
    data = NULL;
 


### PR DESCRIPTION
## Summary

Adds Prometheus metrics to capture client connection wait behavior.

## Changes

- Add `pgagroal_max_wait_time` to track the maximum client wait time.
- Add `pgagroal_total_wait_time` to track the total accumulated client wait time.
- Update Prometheus documentation and scrape metadata.
- Update the Grafana dashboard to include the new metrics.

Closes #1048