### PR TITLE
Bound the message walk in extract_message

### DIFF
--- a/src/libpgagroal/utils.c
+++ b/src/libpgagroal/utils.c
@@ -174,16 +174,39 @@ pgagroal_extract_message(char type, struct message* msg, struct message** extrac
    offset = 0;
    *extracted = NULL;
 
-   while (result == NULL && offset < msg->length)
+   /* Every message is a kind byte followed by a four byte length that
+      covers itself, so anything shorter cannot hold a header. */
+   while (result == NULL && offset + 5 <= msg->length)
    {
       char t = (char)pgagroal_read_byte(msg->data + offset);
 
+      m_length = pgagroal_read_int32(msg->data + offset + 1);
+
+      /* The length is read off the wire. Compared by subtraction because
+         offset + 1 + m_length would overflow for a large m_length, and it
+         is also what advances offset, so a value below 4 would not make
+         progress. */
+      if (m_length < 4 || m_length > msg->length - offset - 1)
+      {
+         return 1;
+      }
+
       if (type == t)
       {
-         m_length = pgagroal_read_int32(msg->data + offset + 1);
-
          result = (struct message*)malloc(sizeof(struct message));
+
+         if (result == NULL)
+         {
+            return 1;
+         }
+
          data = (void*)malloc(1 + m_length);
+
+         if (data == NULL)
+         {
+            free(result);
+            return 1;
+         }
 
          memcpy(data, msg->data + offset, 1 + m_length);
 
@@ -197,8 +220,7 @@ pgagroal_extract_message(char type, struct message* msg, struct message** extrac
       }
       else
       {
-         offset += 1;
-         offset += pgagroal_read_int32(msg->data + offset);
+         offset += 1 + m_length;
       }
    }
 


### PR DESCRIPTION
Fixes #1051.

`pgagroal_extract_message()` read the length field off the wire and used it unchecked, in three ways: the skip step could not make progress on a negative length, the same length was used as both the `malloc` and `memcpy` size without being compared against the remaining bytes, and neither allocation was checked.

Running the loop verbatim, old against new:

```
well formed: skip 'E', find 'Z'
   OLD: malloc(5) and memcpy(5)          NEW: malloc(5) and memcpy(5)

a preceding message declares length -1
   OLD: HANGS after 1000001 iterations   NEW: rejected the message

the wanted message claims 4000 bytes, 10 present
   OLD: reads 3991 bytes past the message  NEW: rejected the message

the wanted message declares length -8
   OLD: malloc(-7) and memcpy(-7)        NEW: rejected the message
```

The first line is the regression check — well-formed input is unaffected.

The header is now read only when five bytes remain, a length below 4 or past the end of the message is rejected, both allocations are checked, and the skip advances by the validated length. The bound is compared by subtraction because `offset + 1 + m_length` would overflow for a large `m_length`.

pgagroal parses these messages from both the client and the server side, so the input is not entirely under its own control. I have not driven a malformed message through a live connection — the results above are the parse loop run on its own, so the reachability argument is from reading.

The same function exists in the other three projects (pgmoneta/pgmoneta#1277). Not cross-porting until you ask.

## Verification

Builds clean and `clang-format` reports no changes. I could not run the suite: `pgagroal_test` wants `<dir> <user> <db>` and a live PostgreSQL, and prints nothing without one.
